### PR TITLE
rename UNK to <unk>

### DIFF
--- a/xnmt/input.py
+++ b/xnmt/input.py
@@ -45,7 +45,7 @@ class PlainTextReader(InputReader):
 
   def freeze(self):
     self.vocab.freeze()
-    self.vocab.set_unk('UNK')
+    self.vocab.set_unk('<unk>')
 
     
 class FeatVecReader(InputReader):


### PR DESCRIPTION
"UNK" might easily occur in real-world text, better to escape it.
https://www.unk.edu