### PR TITLE
Option for residual connections to last layer

### DIFF
--- a/experiments.md
+++ b/experiments.md
@@ -64,3 +64,4 @@ and `<experiment-name>.err.log` in the current directory.
 | decoder_layers |  | int | 2 |
 | encoder_type |  | str | BiLSTM |
 | decoder_type |  | str | LSTM |
+| residual_to_output | If using residual networks, whether to add a residual connection to the output layer | bool | True |

--- a/xnmt/encoder.py
+++ b/xnmt/encoder.py
@@ -33,10 +33,10 @@ class BiLSTMEncoder(DefaultEncoder):
 
 class ResidualLSTMEncoder(DefaultEncoder):
 
-  def __init__(self, layers, output_dim, embedder, model):
+  def __init__(self, layers, output_dim, embedder, model, residual_to_output=False):
     self.embedder = embedder
     input_dim = embedder.emb_dim
-    self.encoder = residual.ResidualRNNBuilder(layers, input_dim, output_dim, model, dy.LSTMBuilder)
+    self.encoder = residual.ResidualRNNBuilder(layers, input_dim, output_dim, model, dy.LSTMBuilder, residual_to_output)
     self.serialize_params = [layers, output_dim, embedder, model]
 
 class ResidualBiLSTMEncoder(DefaultEncoder):
@@ -44,10 +44,11 @@ class ResidualBiLSTMEncoder(DefaultEncoder):
   Implements a residual encoder with bidirectional first layer
   """
 
-  def __init__(self, layers, output_dim, embedder, model):
+  def __init__(self, layers, output_dim, embedder, model, residual_to_output=False):
     self.embedder = embedder
     input_dim = embedder.emb_dim
-    self.encoder = residual.ResidualBiRNNBuilder(layers, input_dim, output_dim, model, dy.LSTMBuilder)
+    self.encoder = residual.ResidualBiRNNBuilder(layers, input_dim, output_dim, model, dy.LSTMBuilder,
+                                                 residual_to_output)
     self.serialize_params = [layers, output_dim, embedder, model]
 
 class PyramidalBiLSTMEncoder(DefaultEncoder):

--- a/xnmt/xnmt_train.py
+++ b/xnmt/xnmt_train.py
@@ -42,6 +42,8 @@ options = [
   Option("decoder_layers", int, default_value=2),
   Option("encoder_type", default_value="BiLSTM"),
   Option("decoder_type", default_value="LSTM"),
+  Option("residual_to_output", bool, default_value=True,
+         help="If using residual networks, whether to add a residual connection to the output layer"),
 ]
 
 class XnmtTrainer:
@@ -63,9 +65,11 @@ class XnmtTrainer:
     if encoder_type == "BiLSTM".lower():
       encoder_builder = BiLSTMEncoder
     elif encoder_type == "ResidualLSTM".lower():
-      encoder_builder = ResidualLSTMEncoder
+      encoder_builder = lambda encoder_layers, encoder_hidden_dim, input_embedder, model:\
+        ResidualLSTMEncoder(encoder_layers, encoder_hidden_dim, input_embedder, model, args.residual_to_output)
     elif encoder_type == "ResidualBiLSTM".lower():
-      encoder_builder = ResidualBiLSTMEncoder
+      encoder_builder = lambda encoder_layers, encoder_hidden_dim, input_embedder, model:\
+        ResidualBiLSTMEncoder(encoder_layers, encoder_hidden_dim, input_embedder, model, args.residual_to_output)
     elif encoder_type == "PyramidalBiLSTM".lower():
       encoder_builder = PyramidalBiLSTMEncoder
     else:
@@ -76,7 +80,7 @@ class XnmtTrainer:
       decoder_builder = dy.LSTMBuilder
     elif decoder_type == "ResidualLSTM".lower():
       decoder_builder = lambda num_layers, input_dim, hidden_dim, model: \
-        residual.ResidualRNNBuilder(num_layers, input_dim, hidden_dim, model, dy.LSTMBuilder)
+        residual.ResidualRNNBuilder(num_layers, input_dim, hidden_dim, model, dy.LSTMBuilder, args.residual_to_output)
     else:
       raise RuntimeError("Unkonwn decoder type {}".format(encoder_type))
 


### PR DESCRIPTION
Most papers I could find do add a residual connection to the output. Google's papers aren't explicit about it (although interesting they say that "residual connections start from the layer third from the bottom in the encoder and decoder").

Also fixed bidirectional residual LSTM.