### PR TITLE
extend batches across buckets to fill up the batch size

### DIFF
--- a/xnmt/batcher.py
+++ b/xnmt/batcher.py
@@ -132,10 +132,12 @@ class BucketBatcher(Batcher):
   def pack(self, source, target):
     source_target_pairs = zip(source, target)
     buckets = self.group_by_len(source_target_pairs)
-    result = []
-    for same_len_pairs in buckets.values():
+    sorted_pairs = []
+    for bucket_key in sorted(buckets.keys()):
+      same_len_pairs = buckets[bucket_key]
       self.bucket_value_sort(same_len_pairs)
-      result.extend(self.create_batches(same_len_pairs))
+      sorted_pairs.extend(same_len_pairs)
+    result = self.create_batches(sorted_pairs)
     np.random.shuffle(result)
     return self.separate_source_target(result)
 


### PR DESCRIPTION
Previously, the bucket batcher put only sentences of the same length into each batch, which can lead to frequent batches far smaller than the requested batch size (especially when using characters etc as tokens). Instead, I changed the behavior to sort by bucket index and then create batches that can include sentences from adjacent buckets. That's probably the more standard behavior.