### PR TITLE
add optional arguments to pass to dynet

### DIFF
--- a/xnmt/xnmt_decode.py
+++ b/xnmt/xnmt_decode.py
@@ -12,6 +12,8 @@ This will be the main class to perform decoding.
 '''
 
 options = [
+  Option("dynet-mem", int, required=False),
+  Option("dynet-gpu-ids", int, required=False),
   Option("model_file", force_flag=True, required=True, help="pretrained (saved) model path"),
   Option("source_file", help="path of input source file to be translated"),
   Option("target_file", help="path of file where expected target translatons will be written"),

--- a/xnmt/xnmt_run_experiments.py
+++ b/xnmt/xnmt_run_experiments.py
@@ -58,6 +58,7 @@ if __name__ == '__main__':
   argparser.add_argument("--dynet-seed", type=int)
   argparser.add_argument("--dynet-viz", action='store_true', help="use visualization")
   argparser.add_argument("--dynet-gpu", action='store_true', help="use GPU acceleration")
+  argparser.add_argument("--dynet-gpu-ids", type=int)
   argparser.add_argument("--generate-doc", action='store_true', help="Do not run, output documentation instead")
   argparser.add_argument("experiments_file")
   argparser.add_argument("experiment_name", nargs='*', help="Run only the specified experiments")

--- a/xnmt/xnmt_train.py
+++ b/xnmt/xnmt_train.py
@@ -21,6 +21,8 @@ This will be the main class to perform training.
 '''
 
 options = [
+  Option("dynet-mem", int, required=False),
+  Option("dynet-gpu-ids", int, required=False),
   Option("eval_every", int, default_value=1000, force_flag=True),
   Option("batch_size", int, default_value=32, force_flag=True),
   Option("batch_strategy", default_value="src"),


### PR DESCRIPTION
A couple of common dynet flags  (`--dynet-mem` and `--dynet-gpu-ids`) can be necessary for running xnmt.
As of now, both flags cause argparse to throw an error in both xnmt_train and xnmt_decode. `--dynet-gpu-ids` also causes argparse to crash in xnmt_run_experiment.

This commit adds the flags as optional arguments so they can be passed transparently to dynet. 