### PR TITLE
Encoder spec via dictionaries

### DIFF
--- a/examples/debug.yaml
+++ b/examples/debug.yaml
@@ -21,7 +21,8 @@ defaults:
 
 debug-config-1layer:
   train:
-    encoder_layers: 1
+    encoder:
+      layers: 2
 
 debug-config-2layers:
   train:

--- a/examples/modular.yaml
+++ b/examples/modular.yaml
@@ -4,32 +4,32 @@ defaults:
     run_for_epochs: 2
     decode_every: 1
     eval_metrics: bleu,wer
-    out_file: ../examples/output/out.log
-    err_file: ../examples/output/out.log.err
+    out_file: examples/output/out.log
+    err_file: examples/output/out.log.err
   train:
-    train_src: ../examples/data/head.ja
-    train_trg: ../examples/data/head.en
-    dev_src: ../examples/data/head.ja
-    dev_trg: ../examples/data/head.en
-    encoder:
+    train_src: examples/data/head.ja
+    train_trg: examples/data/head.en
+    dev_src: examples/data/head.ja
+    dev_trg: examples/data/head.en
+    encoder: 
       type: modular
       modules:
-      - type: bilstm
+      - type: BiLSTM
         input_dim: 64
         output_dim: 64
         layers: 1
-      - type: pyramidallstm
+      - type: PyramidalBiLSTM
         input_dim: 64
         output_dim: 64
         layers: 1
     default_layer_dim: 64
   decode:
-    src_file: ../examples/data/head.ja
+    src_file: examples/data/head.ja
   evaluate:
-    ref_file: ../examples/data/head.en
+    ref_file: examples/data/head.en
 
 debug-config-1layer:
   experiment:
-    model_file: ../examples/output/debug-config-1layer.mod
-    hyp_file: ../examples/output/debug-config-1layer.out
+    model_file: examples/output/debug-config-1layer.mod
+    hyp_file: examples/output/debug-config-1layer.out
 

--- a/examples/modular.yaml
+++ b/examples/modular.yaml
@@ -1,0 +1,35 @@
+# This is a super-small config just for debugging
+defaults:
+  experiment:
+    run_for_epochs: 2
+    decode_every: 1
+    eval_metrics: bleu,wer
+    out_file: ../examples/output/out.log
+    err_file: ../examples/output/out.log.err
+  train:
+    train_src: ../examples/data/head.ja
+    train_trg: ../examples/data/head.en
+    dev_src: ../examples/data/head.ja
+    dev_trg: ../examples/data/head.en
+    encoder:
+      type: modular
+      modules:
+      - type: bilstm
+        input_dim: 64
+        output_dim: 64
+        layers: 1
+      - type: pyramidallstm
+        input_dim: 64
+        output_dim: 64
+        layers: 1
+    default_layer_dim: 64
+  decode:
+    src_file: ../examples/data/head.ja
+  evaluate:
+    ref_file: ../examples/data/head.en
+
+debug-config-1layer:
+  experiment:
+    model_file: ../examples/output/debug-config-1layer.mod
+    hyp_file: ../examples/output/debug-config-1layer.out
+

--- a/examples/speech.yaml
+++ b/examples/speech.yaml
@@ -17,7 +17,8 @@ defaults:
     dev_src: examples/data/synth.contvec.npz
     dev_trg: examples/data/synth.char
     # choose pyramidal LSTM encoder:
-    encoder_type: PyramidalBiLSTM
+    encoder:
+      type: PyramidalBiLSTM
     # indicate the dimension of the feature vectors:
     input_word_embed_dim: 240
     # indicates that the src-side data is continuous-space vectors, contained in a numpy archive (see input.py for details):
@@ -30,10 +31,11 @@ defaults:
 
 speech:
   train:
-    encoder_layers: 2
+    encoder:
+      layers: 2
+      output_dim: 64
     output_word_embed_dim: 64
     output_state_dim: 64
     attender_hidden_dim: 64
     output_mlp_hidden_dim: 64
-    encoder_hidden_dim: 64
 

--- a/examples/speech.yaml
+++ b/examples/speech.yaml
@@ -33,9 +33,10 @@ speech:
   train:
     encoder:
       layers: 2
-      output_dim: 64
+      hidden_dim: 64
     output_word_embed_dim: 64
     output_state_dim: 64
     attender_hidden_dim: 64
     output_mlp_hidden_dim: 64
+    attention_context_dim: 64
 

--- a/xnmt/conv_encoder.py
+++ b/xnmt/conv_encoder.py
@@ -10,7 +10,8 @@ class ConvBiRNNBuilder(object):
   Then, we add a configurable number of bidirectional RNN layers on top.
   """
   
-  def __init__(self, num_layers, input_dim, hidden_dim, model, rnn_builder_factory, chn_dim=3):
+  def __init__(self, num_layers, input_dim, hidden_dim, model, rnn_builder_factory, 
+               chn_dim, num_filters, filter_size_time, filter_size_freq, stride):
     """
     :param num_layers: depth of the RNN
     :param input_dim: size of the inputs
@@ -24,10 +25,10 @@ class ConvBiRNNBuilder(object):
       
     self.chn_dim = chn_dim
     self.freq_dim = input_dim / chn_dim
-    self.num_filters = 32
-    self.filter_size_time = 3
-    self.filter_size_freq = 3
-    self.stride = (2,2)
+    self.num_filters = num_filters # 32
+    self.filter_size_time = filter_size_time # 3
+    self.filter_size_freq = filter_size_freq # 3
+    self.stride = stride # (2,2)
     
     normalInit=dy.NormalInitializer(0, 0.1)
     self.filters1 = model.add_parameters(dim=(self.filter_size_time, self.filter_size_freq, self.chn_dim, self.num_filters),

--- a/xnmt/encoder.py
+++ b/xnmt/encoder.py
@@ -36,7 +36,7 @@ class Encoder:
 
     encoder_type = encoder_spec["type"].lower()
     if encoder_type not in registered_encoders:
-      raise RuntimeError("Unknown encoder type {}".format(encoder_type))
+      raise RuntimeError("Unknown encoder type %s, choices are: %s" % (encoder_type, registered_encoders.keys()))
     return registered_encoders[encoder_type](encoder_spec, model)
 
 class BuilderEncoder(Encoder):
@@ -69,22 +69,22 @@ class BiLSTMEncoder(BuilderEncoder):
     self.builder = dy.BiRNNBuilder(*params)
 
 class ResidualLSTMEncoder(BuilderEncoder):
-  def init_builder(self, input_dim, output_dim, encoder_spec, model):
+  def init_builder(self, encoder_spec, model):
     params = self.use_params(encoder_spec, ["layers", "input_dim", "output_dim", model, dy.VanillaLSTMBuilder, "residual_to_output"])
     self.builder = residual.ResidualRNNBuilder(*params)
 
 class ResidualBiLSTMEncoder(BuilderEncoder):
-  def init_builder(self, input_dim, output_dim, encoder_spec, model):
+  def init_builder(self, encoder_spec, model):
     params = self.use_params(encoder_spec, ["layers", "input_dim", "output_dim", model, dy.VanillaLSTMBuilder, "residual_to_output"])
     self.builder = residual.ResidualBiRNNBuilder(*params)
 
 class PyramidalLSTMEncoder(BuilderEncoder):
-  def init_builder(self, input_dim, output_dim, encoder_spec, model):
+  def init_builder(self, encoder_spec, model):
     params = self.use_params(encoder_spec, ["layers", "input_dim", "output_dim", model, dy.VanillaLSTMBuilder])
     self.builder = pyramidal.PyramidalRNNBuilder(*params)
 
 class ConvBiRNNBuilder(BuilderEncoder):
-  def init_builder(self, input_dim, output_dim, encoder_spec, model):
+  def init_builder(self, encoder_spec, model):
     params = self.use_params(encoder_spec, ["layers", "input_dim", "output_dim", model, dy.VanillaLSTMBuilder,
                                             "chn_dim", "num_filters", "filter_size_time", "filter_size_freq",
                                             "stride"])

--- a/xnmt/encoder.py
+++ b/xnmt/encoder.py
@@ -19,73 +19,91 @@ class Encoder:
     raise NotImplementedError('transduce must be implemented in Encoder subclasses')
 
   @staticmethod
-  def from_spec(spec, layers, input_dim, output_dim, model, residual_to_output):
+  def from_spec(encoder_spec, model):
     """Create an encoder from a specification.
 
-    :param spec: Options include bilstm, residuallstm, residualbylstm, pyramidalbilstm, convbilstm, modular.
-    :param layers: Number of layers
-    :param input_dim: Input dimension
-    :param output_dim: Output dimension
+    :param encoder_spec: Encoder-specific settings (encoders must consume all provided settings)
     :param model: The model that we should add the parameters to
-    :param residual_to_output: For residual encoders, whether to add a residual to the output layer.
     """
-    spec_lower = spec.lower()
-    if spec_lower == "bilstm":
-      return BiLSTMEncoder(layers, input_dim, output_dim, model)
-    elif spec_lower == "residuallstm":
-      return ResidualLSTMEncoder(layers, input_dim, output_dim, model, residual_to_output)
-    elif spec_lower == "residualbilstm":
-      return ResidualBiLSTMEncoder(layers, input_dim, output_dim, model, residual_to_output)
-    elif spec_lower == "pyramidalbilstm":
-      return PyramidalLSTMEncoder(layers, input_dim, output_dim, model)
-    elif spec_lower == "convbilstm":
-      return ConvBiRNNBuilder(layers, input_dim, output_dim, model)
-    elif spec_lower == "modular":
-      # example for a modular encoder: stacked pyramidal encoder, followed by stacked LSTM 
-      return ModularEncoder(model,
-                             PyramidalLSTMEncoder(layers, input_dim, output_dim, model),
-                             BiLSTMEncoder(layers, output_dim, output_dim, model),
-                            )
-    else:
-      raise RuntimeError("Unknown encoder type {}".format(spec_lower))
+    registered_encoders = {
+                         "bilstm" : BiLSTMEncoder,
+                         "residuallstm" : ResidualLSTMEncoder,
+                         "residualbilstm" : ResidualBiLSTMEncoder,
+                         "pyramidalbilstm" : PyramidalLSTMEncoder,
+                         "convbilstm" : ConvBiRNNBuilder,
+                         "modular" : ModularEncoder
+                         }
+
+    encoder_type = encoder_spec["type"].lower()
+    if encoder_type not in registered_encoders:
+      raise RuntimeError("Unknown encoder type {}".format(encoder_type))
+    return registered_encoders[encoder_type](encoder_spec, model)
 
 class BuilderEncoder(Encoder):
+  def __init__(self, encoder_spec, model):
+    self.serialize_params = [encoder_spec, model]
+    self.init_builder(encoder_spec, model)
   def transduce(self, sent):
     return self.builder.transduce(sent)
+  def init_builder(self, encoder_spec, model):
+    raise NotImplementedError("init_builder() must be implemented by BuilderEncoder subclasses")
+  def use_params(self, encoder_spec, params):
+    """
+    Slightly hacky first approach toward formalized documentation / logging.
+    """
+    ret = []
+    print("> encoder %s:" % (encoder_spec["type"]))
+    for param in params:
+      if type(param)==str:
+        if param not in encoder_spec:
+          raise RuntimeError("Missing encoder param %s in encoder %s" % (param, encoder_spec["type"]))
+        ret.append(encoder_spec[param])
+        print("  %s: %s" % (param, ret[-1]))
+      else:
+        ret.append(param)
+    return ret
 
 class BiLSTMEncoder(BuilderEncoder):
-  def __init__(self, layers, input_dim, output_dim, model):
-    self.builder = dy.BiRNNBuilder(layers, input_dim, output_dim, model, dy.VanillaLSTMBuilder)
-    self.serialize_params = [layers, input_dim, output_dim, model]
+  def init_builder(self, encoder_spec, model):
+    params = self.use_params(encoder_spec, ["layers", "input_dim", "output_dim", model, dy.VanillaLSTMBuilder])
+    self.builder = dy.BiRNNBuilder(*params)
 
 class ResidualLSTMEncoder(BuilderEncoder):
-  def __init__(self, layers, input_dim, output_dim, model, residual_to_output):
-    self.builder = residual.ResidualRNNBuilder(layers, input_dim, output_dim, model, dy.VanillaLSTMBuilder, residual_to_output)
-    self.serialize_params = [layers, input_dim, output_dim, model, residual_to_output]
+  def init_builder(self, input_dim, output_dim, encoder_spec, model):
+    params = self.use_params(encoder_spec, ["layers", "input_dim", "output_dim", model, dy.VanillaLSTMBuilder, "residual_to_output"])
+    self.builder = residual.ResidualRNNBuilder(*params)
 
 class ResidualBiLSTMEncoder(BuilderEncoder):
-  def __init__(self, layers, input_dim, output_dim, model, residual_to_output):
-    self.builder = residual.ResidualBiRNNBuilder(layers, input_dim, output_dim, model, dy.VanillaLSTMBuilder, residual_to_output)
-    self.serialize_params = [layers, input_dim, output_dim, model, residual_to_output]
+  def init_builder(self, input_dim, output_dim, encoder_spec, model):
+    params = self.use_params(encoder_spec, ["layers", "input_dim", "output_dim", model, dy.VanillaLSTMBuilder, "residual_to_output"])
+    self.builder = residual.ResidualBiRNNBuilder(*params)
 
 class PyramidalLSTMEncoder(BuilderEncoder):
-  def __init__(self, layers, input_dim, output_dim, model):
-    self.builder = pyramidal.PyramidalRNNBuilder(layers, input_dim, output_dim, model, dy.VanillaLSTMBuilder)
-    self.serialize_params = [layers, input_dim, output_dim, model]
+  def init_builder(self, input_dim, output_dim, encoder_spec, model):
+    params = self.use_params(encoder_spec, ["layers", "input_dim", "output_dim", model, dy.VanillaLSTMBuilder])
+    self.builder = pyramidal.PyramidalRNNBuilder(*params)
 
 class ConvBiRNNBuilder(BuilderEncoder):
-  def __init__(self, layers, input_dim, output_dim, model):
-    self.builder = conv_encoder.ConvBiRNNBuilder(layers, input_dim, output_dim, model, dy.LSTMBuilder)
-    self.serialize_params = [layers, input_dim, output_dim, model]
+  def init_builder(self, input_dim, output_dim, encoder_spec, model):
+    params = self.use_params(encoder_spec, ["layers", "input_dim", "output_dim", model, dy.VanillaLSTMBuilder,
+                                            "chn_dim", "num_filters", "filter_size_time", "filter_size_freq",
+                                            "stride"])
+    self.builder = conv_encoder.ConvBiRNNBuilder(*params)
   
 class ModularEncoder(Encoder):
-  def __init__(self, model, *module_list):
-    self.module_list = module_list
-    self.serialize_params = [model] + list(module_list)
+  def __init__(self, encoder_spec, model):
+    self.modules = []
+    if encoder_spec.get("input_dim", None) != encoder_spec["modules"][0].get("input_dim"):
+      raise RuntimeError("Mismatching input dimensions of first module: %s != %s".format(encoder_spec.get("input_dim", None), encoder_spec["modules"][0].get("input_dim")))
+    if encoder_spec.get("ouput_dim", None) != encoder_spec["modules"][-1].get("ouput_dim"):
+      raise RuntimeError("Mismatching ouput dimensions of last module: %s != %s".format(encoder_spec.get("output_dim", None), encoder_spec["modules"][-1].get("output_dim")))
+    for module_spec in encoder_spec["modules"]:
+      self.modules.append(Encoder.from_spec(module_spec, model))
+    self.serialize_params = [encoder_spec, model]
 
   def transduce(self, sent):
-    for i, module in enumerate(self.module_list):
+    for i, module in enumerate(self.modules):
       sent = module.transduce(sent)
-      if i<len(self.module_list)-1:
+      if i<len(self.modules)-1:
         sent = ExpressionSequence(expr_list=sent)
     return sent

--- a/xnmt/serializer.py
+++ b/xnmt/serializer.py
@@ -48,7 +48,7 @@ class JSONSerializer:
     if hasattr(obj, 'serialize_params'):
       info['__module__'] = obj.__module__
       info['__param__'] = [self.__to_spec(x) for x in obj.serialize_params]
-    elif obj.__class__.__name__ == 'list':
+    elif obj.__class__.__name__ == 'list' or obj.__class__.__name__ == 'dict':
       return json.dumps(obj)
     elif obj.__class__.__name__ != 'Model':
       raise NotImplementedError("Class %s is not serializable. Try adding serialize_params to it." % obj.__class__.__name__)

--- a/xnmt/xnmt_decode.py
+++ b/xnmt/xnmt_decode.py
@@ -14,11 +14,11 @@ This will be the main class to perform decoding.
 options = [
   Option("dynet-mem", int, required=False),
   Option("dynet-gpu-ids", int, required=False),
-  Option("model_file", force_flag=True, required=True, help="pretrained (saved) model path"),
-  Option("src_file", help="path of input src file to be translated"),
-  Option("trg_file", help="path of file where expected trg translatons will be written"),
-  Option("input_format", default_value="text", help="format of input data: text/contvec"),
-  Option("post_process", default_value="none", help="post-processing of translation outputs: none/join-char/join-bpe"),
+  Option("model_file", force_flag=True, required=True, help_str="pretrained (saved) model path"),
+  Option("src_file", help_str="path of input src file to be translated"),
+  Option("trg_file", help_str="path of file where expected trg translatons will be written"),
+  Option("input_format", default_value="text", help_str="format of input data: text/contvec"),
+  Option("post_process", default_value="none", help_str="post-processing of translation outputs: none/join-char/join-bpe"),
   Option("beam", int, default_value=1),
   Option("max_len", int, default_value=100),
 ]

--- a/xnmt/xnmt_evaluate.py
+++ b/xnmt/xnmt_evaluate.py
@@ -4,9 +4,9 @@ from evaluator import BLEUEvaluator, WEREvaluator, CEREvaluator
 from options import Option, OptionParser
 
 options = [
-    Option("ref_file", help="path of the reference file"),
-    Option("hyp_file", help="path of the hypothesis trg file"),
-    Option("evaluator", default_value="bleu", help="Evaluation metrics (bleu/wer/cer)")
+    Option("ref_file", help_str="path of the reference file"),
+    Option("hyp_file", help_str="path of the hypothesis trg file"),
+    Option("evaluator", default_value="bleu", help_str="Evaluation metrics (bleu/wer/cer)")
 ]
 
 

--- a/xnmt/xnmt_run_experiments.py
+++ b/xnmt/xnmt_run_experiments.py
@@ -86,13 +86,13 @@ if __name__ == '__main__':
   config_parser.remove_option("decode", "model_file")
 
   experiment_options = [
-    Option("model_file", default_value="<EXP>.mod", help="Location to write the model file"),
-    Option("hyp_file", default_value="<EXP>.hyp", help="Location to write decoded output for evaluation"),
-    Option("out_file", default_value="<EXP>.out", help="Location to write stdout messages"),
-    Option("err_file", default_value="<EXP>.err", help="Location to write stderr messages"),
-    Option("eval_metrics", default_value="bleu", help="Comma-separated list of evaluation metrics (bleu/wer/cer)"),
-    Option("run_for_epochs", int, help="How many epochs to run each test for"),
-    Option("decode_every", int, default_value=0, help="Evaluation period in epochs. If set to 0, will never evaluate."),
+    Option("model_file", default_value="<EXP>.mod", help_str="Location to write the model file"),
+    Option("hyp_file", default_value="<EXP>.hyp", help_str="Location to write decoded output for evaluation"),
+    Option("out_file", default_value="<EXP>.out", help_str="Location to write stdout messages"),
+    Option("err_file", default_value="<EXP>.err", help_str="Location to write stderr messages"),
+    Option("eval_metrics", default_value="bleu", help_str="Comma-separated list of evaluation metrics (bleu/wer/cer)"),
+    Option("run_for_epochs", int, help_str="How many epochs to run each test for"),
+    Option("decode_every", int, default_value=0, help_str="Evaluation period in epochs. If set to 0, will never evaluate."),
   ]
 
   config_parser.add_task("experiment", experiment_options)

--- a/xnmt/xnmt_train.py
+++ b/xnmt/xnmt_train.py
@@ -31,28 +31,30 @@ options = [
   Option("dev_src"),
   Option("dev_trg"),
   Option("model_file"),
-  Option("pretrained_model_file", default_value="", help="Path of pre-trained model file"),
-  Option("input_vocab", default_value="", help="Path of fixed input vocab file"),
-  Option("output_vocab", default_value="", help="Path of fixed output vocab file"),
-  Option("input_format", default_value="text", help="Format of input data: text/contvec"),
-  Option("default_layer_dim", int, default_value=512, help="Default size to use for layers if not otherwise overridden"),
+  Option("pretrained_model_file", default_value="", help_str="Path of pre-trained model file"),
+  Option("input_vocab", default_value="", help_str="Path of fixed input vocab file"),
+  Option("output_vocab", default_value="", help_str="Path of fixed output vocab file"),
+  Option("input_format", default_value="text", help_str="Format of input data: text/contvec"),
+  Option("default_layer_dim", int, default_value=512, help_str="Default size to use for layers if not otherwise overridden"),
   Option("input_word_embed_dim", int, required=False),
   Option("output_word_embed_dim", int, required=False),
   Option("output_state_dim", int, required=False),
   Option("output_mlp_hidden_dim", int, required=False),
   Option("attender_hidden_dim", int, required=False),
-  Option("encoder_hidden_dim", int, required=False),
   Option("trainer", default_value="sgd"),
   Option("learning_rate", float, default_value=0.1),
   Option("lr_decay", float, default_value=1.0),
   Option("lr_threshold", float, default_value=1e-5),
   Option("eval_metrics", default_value="bleu"),
-  Option("encoder_layers", int, default_value=2),
-  Option("decoder_layers", int, default_value=2),
-  Option("encoder_type", default_value="BiLSTM"),
+  Option("encoder", dict, default_value={}),  
+  Option("encoder.layers", int, default_value=1),
+  Option("encoder.type", default_value="BiLSTM"),
+  Option("encoder.output_dim", int, required=False),
+  Option("encoder.input_dim", int, required=False),
   Option("decoder_type", default_value="LSTM"),
+  Option("decoder_layers", int, default_value=2),
   Option("residual_to_output", bool, default_value=True,
-         help="If using residual networks, whether to add a residual connection to the output layer"),
+         help_str="If using residual networks in the decoder, whether to add a residual connection to the output layer"),
 ]
 
 class XnmtTrainer:
@@ -129,26 +131,29 @@ class XnmtTrainer:
     self.read_data()
     
     # Get layer sizes: replace by default if not specified
-    for opt in ["input_word_embed_dim", "output_word_embed_dim", "output_state_dim", "output_mlp_hidden_dim",
-                "encoder_hidden_dim", "attender_hidden_dim"]:
+    for opt in ["input_word_embed_dim", "output_word_embed_dim", "output_state_dim",
+                "output_mlp_hidden_dim", "attender_hidden_dim", ]:
       if getattr(self.args, opt) is None:
         setattr(self.args, opt, self.args.default_layer_dim)
+    if getattr(self.args, "encoder") is None:
+      self.encoder = {"input_dim":self.args.input_word_embed_dim, "output_dim" : self.args.default_layer_dim}
+    else:
+      if self.args.encoder.get("output_dim", None) is None: self.args.encoder["output_dim"] = self.args.default_layer_dim
+      if self.args.encoder.get("input_dim", None) is None: self.args.encoder["input_dim"] = self.args.input_word_embed_dim
 
     self.input_word_emb_dim = self.args.input_word_embed_dim
     self.output_word_emb_dim = self.args.output_word_embed_dim
     self.output_state_dim = self.args.output_state_dim
     self.attender_hidden_dim = self.args.attender_hidden_dim
     self.output_mlp_hidden_dim = self.args.output_mlp_hidden_dim
-    self.encoder_hidden_dim = self.args.encoder_hidden_dim
+    self.encoder_hidden_dim = self.args.encoder["output_dim"]
 
     self.input_embedder = Embedder.from_spec(self.args.input_format, len(self.input_reader.vocab),
                                              self.input_word_emb_dim, self.model)
 
     self.output_embedder = SimpleWordEmbedder(len(self.output_reader.vocab), self.output_word_emb_dim, self.model)
 
-    self.encoder = Encoder.from_spec(self.args.encoder_type, self.args.encoder_layers,
-                                     self.args.input_word_embed_dim, self.encoder_hidden_dim,
-                                     self.model, self.args.residual_to_output)
+    self.encoder = Encoder.from_spec(self.args.encoder, self.model)
 
     self.attender = StandardAttender(self.encoder_hidden_dim, self.output_state_dim, self.attender_hidden_dim,
                                      self.model)


### PR DESCRIPTION
This is to allow parametrizing encoders arbitrarily from the config files.
We can certainly do more refactoring, but it's ready to use so I thought I'd throw it out now.

One question is whether and how to document encoder parameters. There's 3 parameters that every encoder has: type, input_dim, output_dim. The encoder-specific parameters are kind of formalized in BuilderEncoder.use_params(), we could think about developing this more fully and even creating documentation automatically. I need to take care of other things now, but I'll be making heavy use of this and probably be pushing fixes/updates.