### PR TITLE
refactored encoder module

### DIFF
--- a/examples/debug.yaml
+++ b/examples/debug.yaml
@@ -16,7 +16,7 @@ defaults:
     default_layer_dim: 64
     dropout: 0.5
     encoder:
-      type: PyramidalLSTM
+      type: BiLSTM
       dropout: 0.0
   decode:
     src_file: examples/data/head.ja

--- a/examples/debug.yaml
+++ b/examples/debug.yaml
@@ -16,6 +16,7 @@ defaults:
     default_layer_dim: 64
     dropout: 0.5
     encoder:
+      type: PyramidalLSTM
       dropout: 0.0
   decode:
     src_file: examples/data/head.ja
@@ -24,8 +25,7 @@ defaults:
 
 debug-config-1layer:
   train:
-    encoder:
-      layers: 2
+    dropout: 0.1
 
 debug-config-2layers:
   train:

--- a/examples/modular.yaml
+++ b/examples/modular.yaml
@@ -13,16 +13,16 @@ defaults:
     dev_trg: examples/data/head.en
     dropout: 0.5
     encoder: 
-      type: modular
+      type: Modular
       modules:
       - type: BiLSTM
         input_dim: 64
-        output_dim: 64
+        hidden_dim: 64
         layers: 1
         dropout: 0.1
-      - type: PyramidalBiLSTM
+      - type: PyramidalLSTM
         input_dim: 64
-        output_dim: 64
+        hidden_dim: 64
         layers: 1
     default_layer_dim: 64
   decode:

--- a/xnmt/encoder.py
+++ b/xnmt/encoder.py
@@ -5,11 +5,17 @@ import pyramidal
 import conv_encoder
 from embedder import ExpressionSequence
 from translator import TrainTestInterface
+import inspect
 
 class Encoder(TrainTestInterface):
   """
   A parent class representing all classes that encode inputs.
   """
+  def __init__(self, model, global_train_params, input_dim):
+    """
+    Every encoder constructor needs to accept at least these 3 parameters 
+    """
+    raise NotImplementedError('__init__ must be implemented in Encoder subclasses')
 
   def transduce(self, sent):
     """Encode inputs into outputs.
@@ -20,112 +26,87 @@ class Encoder(TrainTestInterface):
     raise NotImplementedError('transduce must be implemented in Encoder subclasses')
 
   @staticmethod
-  def from_spec(encoder_spec, model):
+  def from_spec(encoder_spec, global_train_params, model):
     """Create an encoder from a specification.
 
     :param encoder_spec: Encoder-specific settings (encoders must consume all provided settings)
+    :param global_train_params: dictionary with global params such as dropout and default_layer_dim, which the encoders are free to make use of.
     :param model: The model that we should add the parameters to
     """
-    registered_encoders = {
-                         "bilstm" : BiLSTMEncoder,
-                         "residuallstm" : ResidualLSTMEncoder,
-                         "residualbilstm" : ResidualBiLSTMEncoder,
-                         "pyramidalbilstm" : PyramidalLSTMEncoder,
-                         "convbilstm" : ConvBiRNNBuilder,
-                         "modular" : ModularEncoder
-                         }
-
-    encoder_type = encoder_spec["type"].lower()
-    if encoder_type not in registered_encoders:
-      raise RuntimeError("Unknown encoder type %s, choices are: %s" % (encoder_type, registered_encoders.keys()))
-    return registered_encoders[encoder_type](encoder_spec, model)
+    encoder_spec = dict(encoder_spec)
+    encoder_type = encoder_spec.pop("type")
+    encoder_spec["model"] = model
+    encoder_spec["global_train_params"] = global_train_params
+    encoder_class = globals().get(encoder_type, globals().get(encoder_type+"Encoder"))
+    try:
+      return encoder_class(**encoder_spec)
+    except TypeError:
+      raise RuntimeError("specified encoder %s is unknown, choices are: %s" 
+                         % (encoder_type,", ".join([key for (key,val) in globals().items() if inspect.isclass(val) and issubclass(val, Encoder)])))
 
 class BuilderEncoder(Encoder):
-  def __init__(self, encoder_spec, model):
-    self.serialize_params = [encoder_spec, model]
-    self.init_builder(encoder_spec, model)
   def transduce(self, sent):
     return self.builder.transduce(sent)
-  def init_builder(self, encoder_spec, model):
-    raise NotImplementedError("init_builder() must be implemented by BuilderEncoder subclasses")
-  def use_params(self, encoder_spec, params, map_to_default_layer_dim):
-    """
-    Slightly hacky first approach toward formalized documentation / logging.
-    """
-    ret = []
-    print("> encoder %s:" % (encoder_spec["type"]))
-    for param in params:
-      if type(param)==str:
-        if param not in encoder_spec:
-          if param in map_to_default_layer_dim and "default_layer_dim" in encoder_spec:
-            val = encoder_spec["default_layer_dim"]
-          else:
-            raise RuntimeError("Missing encoder param %s in encoder %s" % (param, encoder_spec["type"]))
-        else:
-          val = encoder_spec[param]
-        ret.append(val)
-        print("  %s: %s" % (param, val))
-      else:
-        ret.append(param)
-    return ret
 
 class BiLSTMEncoder(BuilderEncoder):
-  def init_builder(self, encoder_spec, model):
-    params = self.use_params(encoder_spec, ["layers", "input_dim", "hidden_dim", model, dy.VanillaLSTMBuilder, "dropout"],
-                             map_to_default_layer_dim=["hidden_dim"])
-    self.dropout = params.pop()
-    self.builder = dy.BiRNNBuilder(*params)
+  def __init__(self, model, global_train_params, input_dim=512, layers=1, hidden_dim=None, dropout=None):
+    if hidden_dim is None: hidden_dim = global_train_params.get("default_layer_dim", 512)
+    if dropout is None: dropout = global_train_params.get("dropout", 0.0)
+    self.dropout = dropout
+    self.builder = dy.BiRNNBuilder(layers, input_dim, hidden_dim, model, dy.VanillaLSTMBuilder)
+    self.serialize_params = [model, global_train_params, input_dim, layers, hidden_dim, dropout]
   def set_train(self, val):
     self.builder.set_dropout(self.dropout if val else 0.0)
 
 class ResidualLSTMEncoder(BuilderEncoder):
-  def init_builder(self, encoder_spec, model):
-    params = self.use_params(encoder_spec, ["layers", "input_dim", "hidden_dim", model, dy.VanillaLSTMBuilder, "residual_to_output", "dropout"],
-                             map_to_default_layer_dim=["hidden_dim"])
-    self.dropout = params.pop()
-    self.builder = residual.ResidualRNNBuilder(*params)
+  def __init__(self, model, global_train_params, input_dim=512, layers=1, hidden_dim=None, residual_to_output=False, dropout=None):
+    if hidden_dim is None: hidden_dim = global_train_params.get("default_layer_dim", 512)
+    if dropout is None: dropout = global_train_params.get("dropout", 0.0)
+    self.dropout = dropout
+    self.builder = residual.ResidualRNNBuilder(layers, input_dim, hidden_dim, model, dy.VanillaLSTMBuilder, residual_to_output)
+    self.serialize_params = [model, global_train_params, input_dim, layers, hidden_dim, residual_to_output, dropout]
   def set_train(self, val):
     self.builder.set_dropout(self.dropout if val else 0.0)
 
 class ResidualBiLSTMEncoder(BuilderEncoder):
-  def init_builder(self, encoder_spec, model):
-    params = self.use_params(encoder_spec, ["layers", "input_dim", "hidden_dim", model, dy.VanillaLSTMBuilder, "residual_to_output", "dropout"],
-                             map_to_default_layer_dim=["hidden_dim"])
-    self.dropout = params.pop()
-    self.builder = residual.ResidualBiRNNBuilder(*params)
+  def __init__(self, model, global_train_params, input_dim=512, layers=1, hidden_dim=None, residual_to_output=False, dropout=None):
+    if hidden_dim is None: hidden_dim = global_train_params.get("default_layer_dim", 512)
+    if dropout is None: dropout = global_train_params.get("dropout", 0.0)
+    self.dropout = dropout
+    self.builder = residual.ResidualBiRNNBuilder(layers, input_dim, hidden_dim, model, dy.VanillaLSTMBuilder, residual_to_output)
+    self.serialize_params = [model, global_train_params, input_dim, layers, hidden_dim, residual_to_output, dropout]
   def set_train(self, val):
     self.builder.set_dropout(self.dropout if val else 0.0)
 
 class PyramidalLSTMEncoder(BuilderEncoder):
-  def init_builder(self, encoder_spec, model):
-    params = self.use_params(encoder_spec, ["layers", "input_dim", "hidden_dim", model, dy.VanillaLSTMBuilder, "downsampling_method", "dropout"],
-                             map_to_default_layer_dim=["hidden_dim"])
-    self.dropout = params.pop()
-    self.builder = pyramidal.PyramidalRNNBuilder(*params)
+  def __init__(self, model, global_train_params, input_dim=512, layers=1, hidden_dim=None, downsampling_method="skip", dropout=None):
+    if hidden_dim is None: hidden_dim = global_train_params.get("default_layer_dim", 512)
+    if dropout is None: dropout = global_train_params.get("dropout", 0.0)
+    self.dropout = dropout
+    self.builder = pyramidal.PyramidalRNNBuilder(layers, input_dim, hidden_dim, model, dy.VanillaLSTMBuilder, downsampling_method)
+    self.serialize_params = [model, global_train_params, input_dim, layers, hidden_dim, downsampling_method, dropout]
   def set_train(self, val):
     self.builder.set_dropout(self.dropout if val else 0.0)
 
 class ConvBiRNNBuilder(BuilderEncoder):
-  def init_builder(self, encoder_spec, model):
-    params = self.use_params(encoder_spec, ["layers", "input_dim", "hidden_dim", model, dy.VanillaLSTMBuilder,
-                                            "chn_dim", "num_filters", "filter_size_time", "filter_size_freq",
-                                            "stride", "dropout"])
-    self.dropout = params.pop()
-    self.builder = conv_encoder.ConvBiRNNBuilder(*params)
+  def init_builder(self, model, global_train_params, input_dim, layers, hidden_dim=None, chn_dim=3, num_filters=32, filter_size_time=3, filter_size_freq=3, stride=(2,2), dropout=None):
+    if hidden_dim is None: hidden_dim = global_train_params.get("default_layer_dim", 512)
+    if dropout is None: dropout = global_train_params.get("dropout", 0.0)
+    self.dropout = dropout
+    self.builder = conv_encoder.ConvBiRNNBuilder(layers, input_dim, hidden_dim, model, dy.VanillaLSTMBuilder,
+                                            chn_dim, num_filters, filter_size_time, filter_size_freq, stride)
+    self.serialize_params = [model, global_train_params, input_dim, layers, hidden_dim, chn_dim, num_filters, filter_size_time, filter_size_freq, stride, dropout]
   def set_train(self, val):
     self.builder.set_dropout(self.dropout if val else 0.0)
   
 class ModularEncoder(Encoder):
-  def __init__(self, encoder_spec, model):
+  def __init__(self, model, global_train_params, input_dim, modules):
     self.modules = []
-    if encoder_spec.get("input_dim", None) != encoder_spec["modules"][0].get("input_dim"):
-      raise RuntimeError("Mismatching input dimensions of first module: %s != %s".format(encoder_spec.get("input_dim", None), encoder_spec["modules"][0].get("input_dim")))
-    for module_spec in encoder_spec["modules"]:
-      module_spec = dict(module_spec)
-      module_spec["default_layer_dim"] = encoder_spec["default_layer_dim"]
-      if "dropout" not in module_spec: module_spec["dropout"] = encoder_spec["dropout"]
-      self.modules.append(Encoder.from_spec(module_spec, model))
-    self.serialize_params = [encoder_spec, model]
+    if input_dim != modules[0].get("input_dim"):
+      raise RuntimeError("Mismatching input dimensions of first module: %s != %s".format(input_dim, modules[0].get("input_dim")))
+    for module_spec in modules:
+      self.modules.append(Encoder.from_spec(module_spec, global_train_params, model))
+    self.serialize_params = [model, global_train_params, input_dim, modules]
 
   def transduce(self, sent):
     for i, module in enumerate(self.modules):

--- a/xnmt/residual.py
+++ b/xnmt/residual.py
@@ -133,13 +133,13 @@ class ResidualBiRNNBuilder:
     self.residual_network = ResidualRNNBuilder(num_layers - 1, hidden_dim, hidden_dim, model, rnn_builder_factory,
                                                add_to_output)
 
-  def set_droupout(self, p):
+  def set_dropout(self, p):
     self.forward_layer.set_dropout(p)
-    self.backward_layer.set_droupout(p)
+    self.backward_layer.set_dropout(p)
     self.residual_network.set_dropout(p)
 
-  def disable_droupt(self):
-    self.forward_layer.disable_droupout()
+  def disable_dropout(self):
+    self.forward_layer.disable_dropout()
     self.backward_layer.disable_dropout()
     self.residual_network.disable_dropout()
 

--- a/xnmt/xnmt_train.py
+++ b/xnmt/xnmt_train.py
@@ -52,7 +52,6 @@ options = [
   Option("eval_metrics", default_value="bleu"),
   Option("dropout", float, default_value=0.0),
   Option("encoder", dict, default_value={}),  
-  Option("encoder.layers", int, default_value=1),
   Option("encoder.type", default_value="BiLSTM"),
   Option("encoder.input_dim", int, required=False),
   Option("decoder_type", default_value="LSTM"),
@@ -141,8 +140,6 @@ class XnmtTrainer:
         setattr(self.args, opt, self.args.default_layer_dim)
     if getattr(self.args, "encoder") is None:
       self.args.encoder = {}
-    self.args.encoder["default_layer_dim"] = self.args.default_layer_dim
-    if "dropout" not in self.args.encoder: self.args.encoder["dropout"] = self.args.dropout
     if self.args.encoder.get("input_dim", None) is None: self.args.encoder["input_dim"] = self.args.input_word_embed_dim
 
     self.input_word_emb_dim = self.args.input_word_embed_dim
@@ -157,7 +154,8 @@ class XnmtTrainer:
 
     self.output_embedder = SimpleWordEmbedder(len(self.output_reader.vocab), self.output_word_emb_dim, self.model)
 
-    self.encoder = Encoder.from_spec(self.args.encoder, self.model)
+    global_train_params = {"dropout" : self.args.dropout, "default_layer_dim":self.args.default_layer_dim}
+    self.encoder = Encoder.from_spec(self.args.encoder, global_train_params, self.model)
 
     self.attender = StandardAttender(self.attention_context_dim, self.output_state_dim, self.attender_hidden_dim,
                                      self.model)


### PR DESCRIPTION
Code is a bit cleaner now. A last remaining refactoring step might be to collapse related encoders that have the same parameters into one encoder class.