### PR TITLE
Solved porting problem

### DIFF
--- a/xnmt/evaluator.py
+++ b/xnmt/evaluator.py
@@ -1,7 +1,6 @@
 from __future__ import division, generators
 import numpy as np
 from collections import defaultdict, Counter
-from six.moves.builtins import range, map
 import math
 
 class EvalScore(object):
@@ -279,8 +278,6 @@ class WEREvaluator(Evaluator):
             return -1
 
     def seq_sim(self, l1, l2):
-        l1 = list(l1)
-        l2 = list(l2)
         # compute matrix
         F = [[0] * (len(l2) + 1) for i in range((len(l1) + 1))]
         for i in range(len(l1) + 1):

--- a/xnmt/input.py
+++ b/xnmt/input.py
@@ -1,7 +1,7 @@
 import numpy as np
-import itertools
 import os
 import io
+import six
 from collections import defaultdict
 from six.moves import zip
 from serializer import Serializable
@@ -170,8 +170,8 @@ class BilingualCorpusParser(CorpusParser, Serializable):
   def read_training_corpus(self, training_corpus):
     training_corpus.train_src_data = []
     training_corpus.train_trg_data = []
-    for src_sent, trg_sent in itertools.izip(self.src_reader.read_sents(training_corpus.train_src, self.max_num_train_sents), 
-                                             self.trg_reader.read_sents(training_corpus.train_trg, self.max_num_train_sents)):
+    for src_sent, trg_sent in six.moves.zip(self.src_reader.read_sents(training_corpus.train_src, self.max_num_train_sents),
+                                            self.trg_reader.read_sents(training_corpus.train_trg, self.max_num_train_sents)):
       src_len_ok = self.max_src_len is None or len(src_sent) <= self.max_src_len
       trg_len_ok = self.max_trg_len is None or len(trg_sent) <= self.max_trg_len
       if src_len_ok and trg_len_ok:
@@ -181,8 +181,8 @@ class BilingualCorpusParser(CorpusParser, Serializable):
     self.trg_reader.freeze()
     training_corpus.dev_src_data = []
     training_corpus.dev_trg_data = []
-    for src_sent, trg_sent in itertools.izip(self.src_reader.read_sents(training_corpus.dev_src, self.max_num_dev_sents),
-                                             self.trg_reader.read_sents(training_corpus.dev_trg, self.max_num_dev_sents)):
+    for src_sent, trg_sent in six.moves.zip(self.src_reader.read_sents(training_corpus.dev_src, self.max_num_dev_sents),
+                                            self.trg_reader.read_sents(training_corpus.dev_trg, self.max_num_dev_sents)):
       src_len_ok = self.max_src_len is None or len(src_sent) <= self.max_src_len
       trg_len_ok = self.max_trg_len is None or len(trg_sent) <= self.max_trg_len
       if src_len_ok and trg_len_ok:

--- a/xnmt/xnmt_train.py
+++ b/xnmt/xnmt_train.py
@@ -5,6 +5,7 @@ import argparse
 import math
 import sys
 import dynet as dy
+import six
 from embedder import *
 from attender import *
 from input import *
@@ -70,9 +71,9 @@ class XnmtTrainer:
     self.early_stopping_reached = False
     self.cur_attempt = 0
     
-    self.evaluators = map(lambda s: s.lower(), self.args.dev_metrics.split(","))
+    self.evaluators = list(six.moves.map(lambda s: s.lower(), self.args.dev_metrics.split(",")))
     if self.args.schedule_metric.lower() not in self.evaluators:
-              self.evaluators.append(self.args.schedule_metric.lower())    
+              self.evaluators.append(self.args.schedule_metric.lower())
     if "ppl" not in self.evaluators: self.evaluators.append("ppl")
 
     # Initialize the serializer
@@ -224,7 +225,7 @@ class XnmtTrainer:
             self.logger.report_auxiliary_score(eval_scores[metric])
         # Write out the model if it's the best one
         if self.logger.report_dev_and_check_model(self.args.model_file):
-          self.model_serializer.save_to_file(self.args.model_file, 
+          self.model_serializer.save_to_file(self.args.model_file,
                                              ModelParams(self.corpus_parser, self.model, model_globals.params),
                                              model_globals.get("model"))
           self.cur_attempt = 0


### PR DESCRIPTION
map in python2 returns list where in python3 returns generator. I think the best practice is to use the six.moves.map() which returns a generator and put it into the list() constructor if we expect it to produce list. 