### PR TITLE
fixed python2 when writing non-unicode logs

### DIFF
--- a/xnmt/tee.py
+++ b/xnmt/tee.py
@@ -35,7 +35,7 @@ class Tee:
     self.close()
 
   def write(self, data):
-    self.file.write(data)
+    self.file.write(unicode(data))
     self.stdstream.write(" " * self.indent + data)
     self.flush()
 


### PR DESCRIPTION
(got broken by the recent python3 fix)