### PR TITLE
Fixes some python2-3 compatibilities

### DIFF
--- a/xnmt/evaluator.py
+++ b/xnmt/evaluator.py
@@ -2,6 +2,7 @@ from __future__ import division, generators
 import numpy as np
 from collections import defaultdict, Counter
 import math
+import six
 
 class EvalScore(object):
   def higher_is_better(self):
@@ -258,12 +259,12 @@ class WEREvaluator(Evaluator):
 
     def dist_one_pair(self, ref_sent, hyp_sent):
         """
-    :return: tuple (levenshtein distance, reference length) 
+    :return: tuple (levenshtein distance, reference length)
     """
         if not self.case_sensitive:
-            hyp_sent = list(map(lambda w: w.lower(), hyp_sent))
+            hyp_sent = list(six.moves.map(lambda w: w.lower(), hyp_sent))
         if not self.case_sensitive:
-            ref_sent = list(map(lambda w: w.lower(), ref_sent))
+            ref_sent = list(six.moves.map(lambda w: w.lower(), ref_sent))
         return -self.seq_sim(ref_sent, hyp_sent)
 
     # gap penalty:

--- a/xnmt/serializer.py
+++ b/xnmt/serializer.py
@@ -3,6 +3,7 @@ import inspect
 import datetime
 import os
 import sys
+import six
 
 class Serializable(yaml.YAMLObject):
   """
@@ -53,8 +54,7 @@ class YamlSerializer(object):
       if isinstance(val, Serializable):
         obj.serialize_params[name] = val
         self.set_serialize_params_recursive(val)
-      elif type(val) in [type(None), bool, int, float, str, datetime.datetime, dict, set] or \
-           sys.version_info[0] == 2 and type(val) == unicode:
+      elif type(val) in [type(None), bool, int, float, str, type(six.u(val)), datetime.datetime, dict, set]:
         obj.serialize_params[name] = val
       elif type(val)==list:
         obj.serialize_params[name] = val

--- a/xnmt/tee.py
+++ b/xnmt/tee.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import io
+import six
 
 class Tee:
   """
@@ -35,7 +36,7 @@ class Tee:
     self.close()
 
   def write(self, data):
-    self.file.write(unicode(data))
+    self.file.write(six.u(data))
     self.stdstream.write(" " * self.indent + data)
     self.flush()
 


### PR DESCRIPTION
Haven't checked in python2, but I am pretty sure it works.

Btw, we actually need to always use six.moves.map that returns generator as list(map()) expression is 2 times N operations in python2.