### PR TITLE
Added ability to create reports for translations

### DIFF
--- a/examples/debug-report.yaml
+++ b/examples/debug-report.yaml
@@ -1,0 +1,47 @@
+# Small config to help refactoring to make the model completely YAML based
+defaults:
+  experiment:
+    model_file: examples/output/<EXP>.mod
+    hyp_file: examples/output/<EXP>.hyp
+    out_file: examples/output/<EXP>.out
+    err_file: examples/output/<EXP>.err
+    run_for_epochs: 20
+    eval_metrics: bleu
+  train:
+    trainer: adam
+    learning_rate: 0.01
+    default_layer_dim: 256 
+    dropout: 0.0
+    dev_metrics: bleu
+    training_corpus: !BilingualTrainingCorpus
+      train_src: examples/data/head.ja
+      train_trg: examples/data/head.en
+      dev_src: examples/data/head.ja
+      dev_trg: examples/data/head.en
+    corpus_parser: !BilingualCorpusParser
+      src_reader: !PlainTextReader {}
+      trg_reader: !PlainTextReader {}
+      max_src_len: 15
+      max_trg_len: 15
+    model: !DefaultTranslator
+      src_embedder: !SimpleWordEmbedder
+        emb_dim: 256
+      encoder: !LSTMEncoder
+        layers: 1
+        input_dim: 256
+      attender: !StandardAttender
+        state_dim: 256
+        hidden_dim: 256
+        input_dim: 256
+      trg_embedder: !SimpleWordEmbedder
+        emb_dim: 256
+      decoder: !MlpSoftmaxDecoder
+        layers: 1
+        mlp_hidden_dim: 256
+  decode:
+    src_file: examples/data/head.ja
+    report_path: examples/output/<EXP>.report
+  evaluate:
+    ref_file: examples/data/head.en
+
+debug:

--- a/xnmt/reports.py
+++ b/xnmt/reports.py
@@ -1,6 +1,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import dynet as dy
+import os
 
 class DefaultTranslatorReport(object):
   
@@ -44,6 +45,7 @@ class DefaultTranslatorReport(object):
     plt.close()
     
   def write_report(self, path_to_report, idx=None):
+    filename_of_report = os.path.basename(path_to_report)
     with open("{}.html".format(path_to_report), 'w') as f:
       if idx != None:
         f.write("<html><head><title>Translation Report for Sentence {}</title></head><body>\n".format(idx))
@@ -64,12 +66,12 @@ class DefaultTranslatorReport(object):
         elif type(self.attentions) == dy.Expression:
           attention_nparray = self.attentions.npvalue()
         elif type(self.attentions) == list:
-          attention_nparray = np.stack([x.npvalue() for x in self.attentions])
+          attention_nparray = np.concatenate([x.npvalue() for x in self.attentions], axis=1)
         else:
           raise RuntimeError("Illegal type for attentions in translator report: {}".format(type(self.attentions)))
         attention_file = "{}.attention.png".format(path_to_report)
         DefaultTranslatorReport.plot_attention(self.src_words, self.trg_words, attention_nparray, file_name = attention_file)
-        f.write("<p><b>Attention:</b><br/><img src=\"{}.attention.png\"/></p>\n".format(path_to_report))
+        f.write("<p><b>Attention:</b><br/><img src=\"{}.attention.png\"/></p>\n".format(filename_of_report))
 
       f.write("</body></html>")
 

--- a/xnmt/translator.py
+++ b/xnmt/translator.py
@@ -117,7 +117,7 @@ class DefaultTranslator(Translator, Serializable):
 
     return dy.esum(losses)
 
-  def translate(self, src, trg_vocab, search_strategy=None):
+  def translate(self, src, trg_vocab, search_strategy=None, report=None):
     # Not including this as a default argument is a hack to get our documentation pipeline working
     if search_strategy == None:
       search_strategy = BeamSearch(1, len_norm=NoNormalization())
@@ -130,5 +130,8 @@ class DefaultTranslator(Translator, Serializable):
       self.attender.start_sent(encodings)
       self.decoder.initialize()
       output_actions = search_strategy.generate_output(self.decoder, self.attender, self.trg_embedder, src_length=len(sents))
+      if report != None:
+        report.trg_words = [trg_vocab[x] for x in output_actions[1:]] # The first token is the start token
+        report.attentions = self.attender.attention_vecs
       outputs.append(TextOutput(output_actions, trg_vocab))
     return outputs

--- a/xnmt/xnmt_decode.py
+++ b/xnmt/xnmt_decode.py
@@ -6,6 +6,7 @@ from serializer import *
 import sys
 from retriever import *
 from translator import *
+from reports import *
 from search_strategy import *
 from options import OptionParser, Option
 from io import open
@@ -25,6 +26,7 @@ options = [
   Option("max_src_len", int, required=False, help_str="Remove sentences from data to decode that are longer than this on the source side"),
   Option("input_format", default_value="text", help_str="format of input data: text/contvec"),
   Option("post_process", default_value="none", help_str="post-processing of translation outputs: none/join-char/join-bpe"),
+  Option("report_path", str, required=False, help_str="a path to which decoding reports will be written"),
   Option("beam", int, default_value=1),
   Option("max_len", int, default_value=100),
   Option("len_norm_type", str, default_value="NoNormalization"),
@@ -67,14 +69,18 @@ def xnmt_decode(args, model_elements=None):
     generator.index_database()
 
   # Perform generation of output
+  report = None
   with io.open(args.trg_file, 'wt', encoding='utf-8') as fp:  # Saving the translated output to a trg file
-    for src in src_corpus:
+    for idx, src in enumerate(src_corpus):
       if args.max_src_len is not None and len(src) > args.max_src_len:
         trg_sent = NO_DECODING_ATTEMPTED
       else:
         dy.renew_cg()
         if issubclass(generator.__class__, Translator):
-          outputs = generator.translate(src, corpus_parser.trg_reader.vocab, search_strategy)
+          if args.report_path != None:
+            report = DefaultTranslatorReport()
+            report.src_words = [corpus_parser.src_reader.vocab[x] for x in src]
+          outputs = generator.translate(src, corpus_parser.trg_reader.vocab, search_strategy, report=report)
           trg_sent = output_generator.process_outputs(outputs)[0]
           if sys.version_info[0] == 2: assert isinstance(trg_sent, unicode), "Expected unicode as generator output, got %s" % type(trg_sent)
         elif issubclass(generator.__class__, Retriever):
@@ -83,6 +89,9 @@ def xnmt_decode(args, model_elements=None):
           raise RuntimeError("Unknown generator type " + generator.__class__)
 
       fp.write(u"{}\n".format(trg_sent))
+      if report != None:
+        report.write_report("{}.{}".format(args.report_path, idx), idx)
+
 def output_processor_for_spec(spec):
   if spec=="none":
     return PlainTextOutputProcessor()


### PR DESCRIPTION
This commit makes it possible to create HTML reports for each translated sentence, including attention visualization by @shrutijpalaskar . This is not written in a super-extensible way at the moment, but I plan on stress-testing the extensibility by trying to use this for speech-to-text translation, or visualizing layers of the network, etc. This will be added in a future pull request.