### PR TITLE
Made packer re-pack batches at every epoch when shuffling

### DIFF
--- a/xnmt/batcher.py
+++ b/xnmt/batcher.py
@@ -25,6 +25,12 @@ class Batcher(object):
     self.trg_pad_token = trg_pad_token
     self.granularity = granularity
 
+  def is_random(self):
+    """
+    :returns: True if there is some randomness in the batching process, False otherwise. Defaults to false.
+    """
+    return False
+
   @staticmethod
   def mark_as_batch(data):
     if type(data) == Batch:
@@ -102,6 +108,9 @@ class ShuffleBatcher(Batcher):
     order = list(range(len(src)))
     np.random.shuffle(order)
     return self.pack_by_order(src, trg, order)
+
+  def is_random(self):
+    return True
 
 class SortBatcher(Batcher):
   """

--- a/xnmt/xnmt_train.py
+++ b/xnmt/xnmt_train.py
@@ -105,6 +105,7 @@ class XnmtTrainer(object):
   def is_batch_mode(self):
     return not (self.args.batch_size is None or self.args.batch_size == 1 or self.args.batch_strategy.lower() == 'none')
   def pack_batches(self):
+    print("packing batches")
     self.train_src, self.train_trg = \
       self.batcher.pack(self.training_corpus.train_src_data, self.training_corpus.train_trg_data)
     self.dev_src, self.dev_trg = \
@@ -176,10 +177,13 @@ class XnmtTrainer(object):
   def run_epoch(self):
     self.logger.new_epoch()
 
-    if self.args.reload_between_epochs and self.logger.epoch_num > 1:
-      print("Reloading training data..")
-      self.corpus_parser.read_training_corpus(self.training_corpus)
-      if self.is_batch_mode():
+    if self.logger.epoch_num > 1:
+      if self.args.reload_between_epochs:
+        print("Reloading training data..")
+        self.corpus_parser.read_training_corpus(self.training_corpus)
+        if self.is_batch_mode():
+          self.pack_batches()
+      elif self.is_batch_mode() and self.batcher.is_random():
         self.pack_batches()
 
     self.model.set_train(True)


### PR DESCRIPTION
When choice of mini-batches plays a particularly large role in the stability of the training, it might be good to ensure different mini-batches on each epoch. This commit makes this possible by ensuring that the batches are re-created every epoch when using a batcher that includes randomness.