### PR TITLE
Make it possible to measure recall on only a subsample of the database IDs

### DIFF
--- a/examples/retrieval.yaml
+++ b/examples/retrieval.yaml
@@ -16,8 +16,10 @@ defaults:
     training_corpus: !BilingualTrainingCorpus
       train_src: examples/data/train.ja
       train_trg: examples/data/train.allids
+      train_id_file: examples/data/train.allids
       dev_src: examples/data/dev.ja
       dev_trg: examples/data/dev.allids
+      dev_id_file: examples/data/dev.allids
     corpus_parser: !BilingualCorpusParser
       src_reader: !PlainTextReader {}
       trg_reader: !IDReader {}
@@ -37,6 +39,7 @@ defaults:
         database_file: examples/data/traindevtest.en
   decode:
     src_file: examples/data/test.ja
+    candidate_id_file: examples/data/test.allids
   evaluate:
     ref_file: examples/data/test.allids
 

--- a/xnmt/training_corpus.py
+++ b/xnmt/training_corpus.py
@@ -6,9 +6,11 @@ class BilingualTrainingCorpus(Serializable):
   """
 
   yaml_tag = "!BilingualTrainingCorpus"
-  def __init__(self, train_src, train_trg, dev_src, dev_trg):
+  def __init__(self, train_src, train_trg, dev_src, dev_trg, train_id_file=None, dev_id_file=None):
     self.train_src = train_src
     self.train_trg = train_trg
+    self.train_id_file = train_id_file
     self.dev_src = dev_src
     self.dev_trg = dev_trg
+    self.dev_id_file = dev_id_file
 

--- a/xnmt/xnmt_decode.py
+++ b/xnmt/xnmt_decode.py
@@ -26,6 +26,7 @@ options = [
   Option("max_src_len", int, required=False, help_str="Remove sentences from data to decode that are longer than this on the source side"),
   Option("input_format", default_value="text", help_str="format of input data: text/contvec"),
   Option("post_process", default_value="none", help_str="post-processing of translation outputs: none/join-char/join-bpe"),
+  Option("candidate_id_file", default_value=None, help_str="if we are doing something like retrieval where we select from fixed candidates, sometimes we want to limit our candidates to a certain subset of the full set. this setting allows us to do this."),
   Option("report_path", str, required=False, help_str="a path to which decoding reports will be written"),
   Option("beam", int, default_value=1),
   Option("max_len", int, default_value=100),
@@ -66,7 +67,11 @@ def xnmt_decode(args, model_elements=None):
   # Perform initialization
   generator.set_train(False)
   if issubclass(generator.__class__, Retriever):
-    generator.index_database()
+    candidates = None
+    if args.candidate_id_file != None:
+      with open(args.candidate_id_file, "r") as f:
+        candidates = sorted({int(x):1 for x in f}.keys())
+    generator.index_database(candidates)
 
   # Perform generation of output
   report = None

--- a/xnmt/xnmt_train.py
+++ b/xnmt/xnmt_train.py
@@ -107,7 +107,6 @@ class XnmtTrainer(object):
   def is_batch_mode(self):
     return not (self.args.batch_size is None or self.args.batch_size == 1 or self.args.batch_strategy.lower() == 'none')
   def pack_batches(self):
-    print("packing batches")
     self.train_src, self.train_trg = \
       self.batcher.pack(self.training_corpus.train_src_data, self.training_corpus.train_trg_data)
     self.dev_src, self.dev_trg = \
@@ -216,6 +215,7 @@ class XnmtTrainer(object):
         eval_scores = {"loss" : loss_score}
         if filter(lambda e: e!="loss", self.evaluators):
           self.decode_args.src_file = self.training_corpus.dev_src
+          self.decode_args.candidate_id_file = self.training_corpus.dev_id_file
           out_file = self.args.model_file + ".dev_hyp"
           out_file_ref = self.args.model_file + ".dev_ref"
           self.decode_args.trg_file = out_file


### PR DESCRIPTION
In retrieval tasks, it's common to only measure retrieval accuracy over the elements in the test database. This commit makes it possible to measure accuracy in this way.