### PR TITLE
make argument explicitly optional because default is None

### DIFF
--- a/xnmt/xnmt_decode.py
+++ b/xnmt/xnmt_decode.py
@@ -26,7 +26,7 @@ options = [
   Option("max_src_len", int, required=False, help_str="Remove sentences from data to decode that are longer than this on the source side"),
   Option("input_format", default_value="text", help_str="format of input data: text/contvec"),
   Option("post_process", default_value="none", help_str="post-processing of translation outputs: none/join-char/join-bpe"),
-  Option("candidate_id_file", default_value=None, help_str="if we are doing something like retrieval where we select from fixed candidates, sometimes we want to limit our candidates to a certain subset of the full set. this setting allows us to do this."),
+  Option("candidate_id_file", required=False, default_value=None, help_str="if we are doing something like retrieval where we select from fixed candidates, sometimes we want to limit our candidates to a certain subset of the full set. this setting allows us to do this."),
   Option("report_path", str, required=False, help_str="a path to which decoding reports will be written"),
   Option("beam", int, default_value=1),
   Option("max_len", int, default_value=100),


### PR DESCRIPTION
Quick matter I picked up while trying to grok the option system:

The example configs are broken right now by missing `candidate_id_file`, an option that seems to be intended to be optional, but is required. 

Specifically, due to [the option parsing at this line](https://github.com/neulab/xnmt/blob/master/xnmt/options.py#L27), an option is required if the `required` flag is set to `True` or if the `required` flag is set to `None`, and the default value is `None`. 

I did not want to accidentally break functionality by changing the default value of `candidate_id_file`, so I made it optional. 