### PR TITLE
Made ContVecReader dimensions be consistent with DyNet ordering

### DIFF
--- a/examples/speech.yaml
+++ b/examples/speech.yaml
@@ -18,7 +18,8 @@ defaults:
       dev_src: examples/data/synth.contvec.npz
       dev_trg: examples/data/synth.char
     corpus_parser: !BilingualCorpusParser
-      src_reader: !ContVecReader {}
+      src_reader: !ContVecReader
+        transpose: True
       trg_reader: !PlainTextReader {}
     model: !DefaultTranslator
       src_embedder: !NoopEmbedder

--- a/xnmt/expression_sequence.py
+++ b/xnmt/expression_sequence.py
@@ -81,8 +81,8 @@ class LazyNumpyExpressionSequence(ExpressionSequence):
       return super(LazyNumpyExpressionSequence, self).__len__()
     else:
       if batcher.is_batched(self.lazy_data):
-        return self.lazy_data[0].shape[0]
-      else: return self.lazy_data.shape[0]
+        return self.lazy_data[0].shape[1]
+      else: return self.lazy_data.shape[1]
   def __iter__(self):
     if not (self.expr_list or self.expr_tensor):
       self.expr_list = [self[i] for i in range(len(self))]
@@ -92,9 +92,9 @@ class LazyNumpyExpressionSequence(ExpressionSequence):
       return super(LazyNumpyExpressionSequence, self).__getitem__(key)
     else:
       if batcher.is_batched(self.lazy_data):
-        return dy.inputTensor([self.lazy_data[batch][key] for batch in range(len(self.lazy_data))], batched=True)
+        return dy.inputTensor([self.lazy_data[batch][:,key] for batch in range(len(self.lazy_data))], batched=True)
       else:
-        return dy.inputTensor(self.lazy_data[key], batched=False)
+        return dy.inputTensor(self.lazy_data[:,key], batched=False)
   def as_tensor(self):
     if not (self.expr_list or self.expr_tensor):
       self.expr_tensor = dy.inputTensor(self.lazy_data, batched=batcher.is_batched(self.lazy_data))

--- a/xnmt/input.py
+++ b/xnmt/input.py
@@ -49,14 +49,14 @@ class ArrayInput(Input):
     self.nparr = nparr
 
   def __len__(self):
-    return self.nparr.__len__()
+    return self.nparr.shape[1] if len(self.nparr.shape) >= 2 else 1
 
   def __getitem__(self, key):
     return self.nparr.__getitem__(key)
 
   def get_padded_sent(self, token, pad_len):
     if pad_len > 0:
-      self.nparr = np.append(self.nparr, np.zeros((pad_len, self.nparr.shape[1])), axis=0)
+      self.nparr = np.append(self.nparr, np.zeros((self.nparr.shape[0], pad_len)), axis=1)
     return self
 
   def get_array(self):
@@ -142,8 +142,11 @@ class ContVecReader(InputReader, Serializable):
   Handles the case where sents are sequences of continuous-space vectors.
 
   We assume a list of matrices (sents) serialized as .npz (with numpy.savez_compressed())
-  Sentences should be named arr_0, arr_1, ... (=np default for unnamed archives).
-  We can index them as sents[sent_no][word_ind,feat_ind]
+  Sentences should be named XXX_0, XXX_1, etc., where the final number after the underbar
+  indicates the order of the sentence in the corpus.
+  Within each sentence, the indices will be:
+  * sents[sent_no][feat_ind,word_ind] if transpose=False
+  * sents[sent_no][word_ind,feat_ind] if transpose=True
   """
   yaml_tag = u"!ContVecReader"
 


### PR DESCRIPTION
Currently `ContVecReader` assumes indexing by `array[word_id,feat_id]` by default, and all downstream processing (padding, etc.) assumes this order. However, while this order makes sense for numpy (which is row major), it's different from DyNet's canonical ordering (which is column major). This causes things to be confusing conceptually, and causes problems when you use continuous vectors through `as_tensor()` e.g. convolutional encoders wouldn't work out-of-the-box.

The PR makes the handling of ordering for input and downstream processing to be `array[feat_id,word_id]`. Most downstream code will not change, as everything is handled in the input classes, but for models inputting arrays in the old format to `ContVecReader`, this means that the `transpose: True` option will have to be added to the configuration file (see the modified `speech.yaml`).