### PR TITLE
Refactoring of RHN Encoder

### DIFF
--- a/xnmt/encoder.py
+++ b/xnmt/encoder.py
@@ -142,8 +142,9 @@ class FullyConnectedEncoder(Encoder, Serializable):
     self.nonlinearity = nonlinearity
     self.with_bias = with_bias
 
-    normalInit=dy.NormalInitializer(0, 0.1)
-    self.pW = model.add_parameters(dim = (self.out_height, self.in_height), init=normalInit)
+    # normalInit=dy.NormalInitializer(0, 0.1)
+    # self.pW = model.add_parameters(dim = (self.out_height, self.in_height), init=normalInit)
+    self.pW = model.add_parameters(dim = (self.out_height, self.in_height))
     if with_bias:
       self.pb = model.add_parameters(dim = self.out_height)
 


### PR DESCRIPTION
This is a refactoring of the RHN encoder to make it more concise. Here are some changes:

1. Instead of relying on external classes, simply adds parameters to the RHN encoder class. Hopefully this makes things a little simpler.
2. Instead of using ExpressionSequences, uses regular DyNet expressions (within the encoder).
3. Fixes a bug (?) where T was using a tanh instead of a sigmoid.

This seems to have fixed the numerical stability issues.