### PR TITLE
Resolving inconsistencies in Beam Search

### DIFF
--- a/xnmt/decoder.py
+++ b/xnmt/decoder.py
@@ -81,6 +81,12 @@ class MlpSoftmaxDecoder(RnnDecoder, Serializable):
     return [set(["layers", "bridge.dec_layers"]),
             set(["lstm_dim", "bridge.dec_dim"])]
 
+  def get_state(self):
+    return (self.state, self.h_t)
+
+  def set_state(self, params):
+    self.state, self.h_t = params
+
   def initialize(self, enc_final_states):
     dec_state = self.fwd_lstm.initial_state()
     self.state = dec_state.set_s(self.bridge.decoder_init(enc_final_states))

--- a/xnmt/search_strategy.py
+++ b/xnmt/search_strategy.py
@@ -68,7 +68,7 @@ class BeamSearch(SearchStrategy):
     
     if forced_trg_ids is not None: assert self.beam_size == 1
     
-    active_hyp = [self.Hypothesis(0, [], decoder.state)]
+    active_hyp = [self.Hypothesis(0, [], decoder.get_state())]
 
     completed_hyp = []
     length = 0
@@ -77,7 +77,7 @@ class BeamSearch(SearchStrategy):
       new_set = []
       for hyp in active_hyp:
 
-        decoder.state = hyp.state
+        decoder.set_state(hyp.state)
         if length > 0: # don't feed in the initial start-of-sentence token
           if hyp.id_list[-1] == Vocab.ES:
             completed_hyp.append(hyp)
@@ -95,7 +95,7 @@ class BeamSearch(SearchStrategy):
           new_list.append(cur_id)
           new_set.append(self.Hypothesis(self.len_norm.normalize_partial(hyp.score, score[cur_id], len(new_list)),
                                          new_list,
-                                         decoder.state))
+                                         decoder.get_state()))
       length += 1
 
       active_hyp = sorted(new_set, key=lambda x: x.score, reverse=True)[:self.beam_size]


### PR DESCRIPTION
Fixing Beam Search to be compatible with the current Decoder.

The following discrepancy was observed by @msperber when using Beam Search for inferencing using a trained model:
```
beam	BLEU	
1	0.294	
2	0.269	
3	0.269	
4	0.265
```	

Test:
Testing on the above model now provides consistency in inference scores. And following BLEU scores were observed:
```
beam	BLEU4	
1	0.2652	
2	0.2751	
3	0.2794
```

Tested on the unit-test suite



