### PR TITLE
added label smoothing term in cost function

### DIFF
--- a/examples/standard.yaml
+++ b/examples/standard.yaml
@@ -36,6 +36,7 @@ defaults:
         layers: 1
         mlp_hidden_dim: 512
         bridge: !CopyBridge {}
+        eps: 0.1
   decode:
     src_file: examples/data/test.ja
   evaluate:
@@ -44,3 +45,4 @@ defaults:
 standard-dropout0.1:
   train:
     dropout: 0.1
+

--- a/examples/standard.yaml
+++ b/examples/standard.yaml
@@ -36,7 +36,7 @@ defaults:
         layers: 1
         mlp_hidden_dim: 512
         bridge: !CopyBridge {}
-        eps: 0.1
+        label_smoothing: 0.1
   decode:
     src_file: examples/data/test.ja
   evaluate:

--- a/xnmt/decoder.py
+++ b/xnmt/decoder.py
@@ -42,15 +42,16 @@ class MlpSoftmaxDecoder(RnnDecoder, Serializable):
   def __init__(self, context, vocab_size, layers=1, input_dim=None, lstm_dim=None,
                mlp_hidden_dim=None, trg_embed_dim=None, dropout=None,
                rnn_spec="lstm", residual_to_output=False, input_feeding=False,
-               bridge=None, eps=0.1):
+               bridge=None, label_smoothing=0.1):
     param_col = context.dynet_param_collection.param_col
     # Define dim
     lstm_dim       = lstm_dim or context.default_layer_dim
     mlp_hidden_dim = mlp_hidden_dim or context.default_layer_dim
     trg_embed_dim  = trg_embed_dim or context.default_layer_dim
     input_dim      = input_dim or context.default_layer_dim
-    self.vocab_size = vocab_size
-    self.eps = eps
+    self.label_smoothing = label_smoothing
+    self.label_smoothing_term = label_smoothing / vocab_size
+
     # Input feeding
     self.input_feeding = input_feeding
     self.lstm_dim = lstm_dim
@@ -117,12 +118,16 @@ class MlpSoftmaxDecoder(RnnDecoder, Serializable):
     scores = self.get_scores(context)
     # single mode
     if not xnmt.batcher.is_batched(ref_action):
-      return dy.pickneglogsoftmax(scores, ref_action)
-    # minibatch mode
+      log_loss = dy.pickneglogsoftmax(scores, ref_action)
+
+    else: # minibatch mode
+      log_loss = dy.pickneglogsoftmax_batch(scores, ref_action)
+
+    if self.label_smoothing == 0.0:
+      return log_loss
     else:
-      ce_loss_term = (1 - self.eps) * (dy.exp(-dy.pickneglogsoftmax_batch(scores, ref_action)))
-      label_smoothing_term = self.eps / self.vocab_size
-      return -dy.log(ce_loss_term + label_smoothing_term)
+      ce_term = (1 - self.label_smoothing) * (dy.exp(-log_loss))
+      return -dy.log(ce_term + self.label_smoothing_term)
 
   @recursive
   def set_train(self, val):

--- a/xnmt/xnmt_decode.py
+++ b/xnmt/xnmt_decode.py
@@ -32,7 +32,7 @@ options = [
   Option("beam", int, default_value=1),
   Option("max_len", int, default_value=100),
   Option("len_norm_type", str, required=False),
-  Option("eps", float, required=True, default_value=0.1, help_str="label smoothing parameter")
+  Option("label_smoothing", float, required=True, default_value=0.1, help_str="label smoothing parameter")
 ]
 
 NO_DECODING_ATTEMPTED = u"@@NO_DECODING_ATTEMPTED@@"

--- a/xnmt/xnmt_decode.py
+++ b/xnmt/xnmt_decode.py
@@ -32,6 +32,7 @@ options = [
   Option("beam", int, default_value=1),
   Option("max_len", int, default_value=100),
   Option("len_norm_type", str, required=False),
+  Option("eps", float, required=True, default_value=0.1, help_str="label smoothing parameter")
 ]
 
 NO_DECODING_ATTEMPTED = u"@@NO_DECODING_ATTEMPTED@@"


### PR DESCRIPTION
added additional term for Label Smoothing in cost function for model regularisation.
This has been shown in a couple of papers to give better BLEU scores and dev loss as it acts to regularise the model.

From my experiments, on the big dataset of jp->en translation task, I got the following results on dev set
i) BLEU: 26.211 (    0.1\*label smoothing   + 0.9\*CE  loss)
ii) BLEU: 25.433  ( only CE  loss )
 