### PR TITLE
Refactor mask

### DIFF
--- a/test/test_batcher.py
+++ b/test/test_batcher.py
@@ -9,7 +9,7 @@ class TestBatcher(unittest.TestCase):
     src_sents = [xnmt.input.SimpleSentenceInput([0] * i) for i in range(1,7)]
     trg_sents = [xnmt.input.SimpleSentenceInput([0] * ((i+3)%6 + 1)) for i in range(1,7)]
     my_batcher = xnmt.batcher.from_spec("src", 3, src_pad_token=1, trg_pad_token=2)
-    src, src_mask, trg, trg_mask = my_batcher.pack(src_sents, trg_sents)
+    src, trg = my_batcher.pack(src_sents, trg_sents)
     self.assertEqual([[0, 1, 1], [0, 0, 1], [0, 0, 0]], [x.words for x in src[0]])
     self.assertEqual([[0, 0, 0, 0, 0, 2], [0, 0, 0, 0, 0, 0], [0, 2, 2, 2, 2, 2]], [x.words for x in trg[0]])
     self.assertEqual([[0, 0, 0, 0, 1, 1], [0, 0, 0, 0, 0, 1], [0, 0, 0, 0, 0, 0]], [x.words for x in src[1]])
@@ -19,7 +19,7 @@ class TestBatcher(unittest.TestCase):
     src_sents = [xnmt.input.SimpleSentenceInput([0] * i) for i in range(1,7)]
     trg_sents = [xnmt.input.SimpleSentenceInput([0] * ((i+3)%6 + 1)) for i in range(1,7)]
     my_batcher = xnmt.batcher.from_spec("word_src", 12, src_pad_token=1, trg_pad_token=2)
-    src, src_mask, trg, trg_mask = my_batcher.pack(src_sents, trg_sents)
+    src, trg = my_batcher.pack(src_sents, trg_sents)
     self.assertEqual([[0]], [x.words for x in src[0]])
     self.assertEqual([[0, 0, 0, 0, 0]], [x.words for x in trg[0]])
     self.assertEqual([[0, 0, 1], [0, 0, 0]], [x.words for x in src[1]])

--- a/test/test_beam_search.py
+++ b/test/test_beam_search.py
@@ -76,8 +76,7 @@ class TestForcedDecodingLoss(unittest.TestCase):
   def test_single(self):
     dy.renew_cg()
     train_loss = self.model.calc_loss(src=self.training_corpus.train_src_data[0],
-                                      trg=self.training_corpus.train_trg_data[0],
-                                      src_mask=None, trg_mask=None).value()
+                                      trg=self.training_corpus.train_trg_data[0]).value()
     dy.renew_cg()
     self.model.initialize_generator(beam=1)
     outputs = self.model.generate_output(self.training_corpus.train_src_data[0], 0,
@@ -117,8 +116,7 @@ class TestFreeDecodingLoss(unittest.TestCase):
 
     dy.renew_cg()
     train_loss = self.model.calc_loss(src=self.training_corpus.train_src_data[0],
-                                      trg=outputs[0][0],
-                                      src_mask=None, trg_mask=None).value()
+                                      trg=outputs[0][0]).value()
 
     self.assertAlmostEqual(-output_score, train_loss, places=5)
 

--- a/test/test_decoding.py
+++ b/test/test_decoding.py
@@ -76,8 +76,7 @@ class TestForcedDecodingLoss(unittest.TestCase):
   def test_single(self):
     dy.renew_cg()
     train_loss = self.model.calc_loss(src=self.training_corpus.train_src_data[0],
-                                      trg=self.training_corpus.train_trg_data[0],
-                                      src_mask=None, trg_mask=None).value()
+                                      trg=self.training_corpus.train_trg_data[0]).value()
     dy.renew_cg()
     self.model.initialize_generator()
     outputs = self.model.generate_output(self.training_corpus.train_src_data[0], 0,
@@ -117,8 +116,7 @@ class TestFreeDecodingLoss(unittest.TestCase):
 
     dy.renew_cg()
     train_loss = self.model.calc_loss(src=self.training_corpus.train_src_data[0],
-                                      trg=outputs[0][0],
-                                      src_mask=None, trg_mask=None).value()
+                                      trg=outputs[0][0]).value()
 
     self.assertAlmostEqual(-output_score, train_loss, places=5)
 

--- a/xnmt/attender.py
+++ b/xnmt/attender.py
@@ -62,8 +62,7 @@ class StandardAttender(Attender, Serializable):
     h = dy.tanh(dy.colwise_add(self.WI, V * state))
     scores = dy.transpose(U * h)
     if self.curr_sent.mask is not None:
-      mask_expr = dy.inputTensor(np.expand_dims(self.curr_sent.mask.np_arr.transpose(), axis=1) * (-100.0), batched=True)
-      scores = scores + mask_expr
+      scores = self.curr_sent.mask.add_to_tensor_expr(scores, multiplicator = -100.0)
     normalized = dy.softmax(scores)
     self.attention_vecs.append(normalized)
     return normalized

--- a/xnmt/attender.py
+++ b/xnmt/attender.py
@@ -62,7 +62,7 @@ class StandardAttender(Attender, Serializable):
     h = dy.tanh(dy.colwise_add(self.WI, V * state))
     scores = dy.transpose(U * h)
     if self.curr_sent.mask is not None:
-      mask_expr = dy.inputTensor(np.expand_dims(self.curr_sent.mask.transpose(), axis=1) * (-100.0), batched=True)
+      mask_expr = dy.inputTensor(np.expand_dims(self.curr_sent.mask.np_arr.transpose(), axis=1) * (-100.0), batched=True)
       scores = scores + mask_expr
     normalized = dy.softmax(scores)
     self.attention_vecs.append(normalized)

--- a/xnmt/batcher.py
+++ b/xnmt/batcher.py
@@ -2,17 +2,24 @@ from __future__ import division, generators
 
 import numpy as np
 import six
-import xnmt.vocab
-
-# Shortnames
-Vocab = xnmt.vocab.Vocab
+from xnmt.vocab import Vocab
 
 class Batch(list):
   """
-  A marker class to indicate a batch.
+  Specialization of list that indicates a (mini)batch of things, together with an optional mask.
+  Should be treated as immutable object.
   """
-  pass
-
+  def __init__(self, batch_list, mask=None):
+    super(Batch, self).__init__(batch_list)
+    self.mask = mask
+  
+class Mask(object):
+  """
+  Masks are represented as numpy array of dimensions batchsize x seq_len, with parts
+  belonging to the sequence set to 0, and parts that should be masked set to 1
+  """
+  def __init__(self, np_arr):
+    self.np_arr = np_arr
 
 class Batcher(object):
   """
@@ -31,35 +38,33 @@ class Batcher(object):
     """
     return False
 
-  def add_single_batch(self, src_curr, trg_curr, src_ret, trg_ret, src_masks, trg_masks):
-     src_id, src_mask = pad(src_curr, pad_token=self.src_pad_token)
-     src_ret.append(Batch(src_id))
-     src_masks.append(src_mask)
-     trg_id, trg_mask = pad(trg_curr, pad_token=self.trg_pad_token)
-     trg_ret.append(Batch(trg_id))
-     trg_masks.append(trg_mask)
+  def add_single_batch(self, src_curr, trg_curr, src_ret, trg_ret):
+    src_id, src_mask = pad(src_curr, pad_token=self.src_pad_token)
+    src_ret.append(Batch(src_id, src_mask))
+    trg_id, trg_mask = pad(trg_curr, pad_token=self.trg_pad_token)
+    trg_ret.append(Batch(trg_id, trg_mask))
 
   def pack_by_order(self, src, trg, order):
-    src_ret, src_curr, src_masks = [], [], []
-    trg_ret, trg_curr, trg_masks = [], [], []
+    src_ret, src_curr = [], []
+    trg_ret, trg_curr = [], []
     if self.granularity == 'sent':
       for x in six.moves.range(0, len(order), self.batch_size):
-        self.add_single_batch([src[y] for y in order[x:x+self.batch_size]], [trg[y] for y in order[x:x+self.batch_size]], src_ret, trg_ret, src_masks, trg_masks)
+        self.add_single_batch([src[y] for y in order[x:x+self.batch_size]], [trg[y] for y in order[x:x+self.batch_size]], src_ret, trg_ret)
     elif self.granularity == 'word':
       my_size = 0
       for i in order:
         my_size += len_or_zero(src[i]) + len_or_zero(trg[i])
         if my_size > self.batch_size:
-          self.add_single_batch(src_curr, trg_curr, src_ret, trg_ret, src_masks, trg_masks)
+          self.add_single_batch(src_curr, trg_curr, src_ret, trg_ret)
           my_size = len(src[i]) + len(trg[i])
           src_curr = []
           trg_curr = []
         src_curr.append(src[i])
         trg_curr.append(trg[i])
-      self.add_single_batch(src_curr, trg_curr, src_ret, trg_ret, src_masks, trg_masks)
+      self.add_single_batch(src_curr, trg_curr, src_ret, trg_ret)
     else:
       raise RuntimeError("Illegal granularity specification {}".format(self.granularity))
-    return src_ret, src_masks, trg_ret, trg_masks
+    return src_ret, trg_ret
 
 class InOrderBatcher(Batcher):
   """
@@ -99,11 +104,11 @@ class SortBatcher(Batcher):
     return self.pack_by_order(src, trg, order)
 
 # Module level functions
-def mark_as_batch(data):
-  if type(data) == Batch:
+def mark_as_batch(data, mask=None):
+  if type(data) == Batch and mask is None:
     ret = data
   else:
-    ret = Batch(data)
+    ret = Batch(data, mask)
   return ret
 
 
@@ -120,7 +125,7 @@ def pad(batch, pad_token=Vocab.ES):
     for j in range(len_or_zero(v), max_len):
       masks[i,j] = 1.0
   padded_items = [item.get_padded_sent(pad_token, max_len - len(item)) for item in batch]
-  return padded_items, masks
+  return padded_items, Mask(masks)
 
 def len_or_zero(val):
   return len(val) if hasattr(val, '__len__') else 0

--- a/xnmt/batcher.py
+++ b/xnmt/batcher.py
@@ -26,7 +26,6 @@ class Mask(object):
     return Mask(self.np_arr[:,::-1])
   
   def add_to_tensor_expr(self, tensor_expr, multiplicator=None):
-    # TODO: check if all zeros, in that case we can just return tensor_expr
     # TODO: might cache these expressions to save memory
     if np.count_nonzero(self.np_arr) == 0:
       return tensor_expr

--- a/xnmt/expression_sequence.py
+++ b/xnmt/expression_sequence.py
@@ -146,7 +146,7 @@ class ReversedExpressionSequence(ExpressionSequence):
     if base_expr_seq.mask is None:
       self.mask = None
     else:
-      self.mask = xnmt.batcher.Mask(base_expr_seq.mask.np_arr[:,::-1])
+      self.mask = base_expr_seq.mask.reversed()
     
   def __len__(self):
     return len(self.base_expr_seq)

--- a/xnmt/expression_sequence.py
+++ b/xnmt/expression_sequence.py
@@ -86,19 +86,6 @@ class ExpressionSequence(object):
     """
     return self.expr_tensor is not None
 
-  def apply_additive_mask(self, val):
-    """Add a constant to all masked values
-    """
-    if type(self.mask) != type(None):
-      if self.expr_tensor:
-        my_mask = dy.inputTensor(np.expand_dims(self.mask, axis=0) * val, batched=True)
-        self.expr_tensor = dy.csum(self.expr_tensor, my_mask)
-      if self.expr_list:
-        for i in range(len(self.expr_list)):
-          col_mask = self.mask[:,i]
-          if col_mask.sum() > 0:
-            self.expr_list[i] += dy.inputTensor(col_mask * val, batched=True)
-
 class LazyNumpyExpressionSequence(ExpressionSequence):
   """
   This is initialized via numpy arrays, and dynet expressions are only created

--- a/xnmt/expression_sequence.py
+++ b/xnmt/expression_sequence.py
@@ -146,7 +146,7 @@ class ReversedExpressionSequence(ExpressionSequence):
     if base_expr_seq.mask is None:
       self.mask = None
     else:
-      self.mask = base_expr_seq.mask[:,::-1]
+      self.mask = xnmt.batcher.Mask(base_expr_seq.mask.np_arr[:,::-1])
     
   def __len__(self):
     return len(self.base_expr_seq)

--- a/xnmt/lstm.py
+++ b/xnmt/lstm.py
@@ -141,8 +141,8 @@ class CustomCompactLSTMBuilder(object):
         c.append(c_t)
         h.append(h_t)
       else:
-        mask_expr = dy.inputTensor(expr_seq[0].mask.transpose()[pos_i:pos_i+1], batched=True)
-        inv_mask_expr = dy.inputTensor(1.0 - expr_seq[0].mask.transpose()[pos_i:pos_i+1], batched=True)
+        mask_expr = dy.inputTensor(expr_seq[0].mask.np_arr.transpose()[pos_i:pos_i+1], batched=True)
+        inv_mask_expr = dy.inputTensor(1.0 - expr_seq[0].mask.np_arr.transpose()[pos_i:pos_i+1], batched=True)
         c.append(dy.cmult(c_t, inv_mask_expr) + dy.cmult(c[-1], mask_expr))
         h.append(dy.cmult(h_t, inv_mask_expr) + dy.cmult(h[-1], mask_expr))
     self._final_states = [FinalEncoderState(h[-1], c[-1])]

--- a/xnmt/lstm.py
+++ b/xnmt/lstm.py
@@ -141,10 +141,8 @@ class CustomCompactLSTMBuilder(object):
         c.append(c_t)
         h.append(h_t)
       else:
-        mask_expr = dy.inputTensor(expr_seq[0].mask.np_arr.transpose()[pos_i:pos_i+1], batched=True)
-        inv_mask_expr = dy.inputTensor(1.0 - expr_seq[0].mask.np_arr.transpose()[pos_i:pos_i+1], batched=True)
-        c.append(dy.cmult(c_t, inv_mask_expr) + dy.cmult(c[-1], mask_expr))
-        h.append(dy.cmult(h_t, inv_mask_expr) + dy.cmult(h[-1], mask_expr))
+        c.append(expr_seq[0].mask.cmult_by_timestep_expr(c_t,pos_i,True) + expr_seq[0].mask.cmult_by_timestep_expr(c[-1],pos_i,False))
+        h.append(expr_seq[0].mask.cmult_by_timestep_expr(h_t,pos_i,True) + expr_seq[0].mask.cmult_by_timestep_expr(h[-1],pos_i,False))
     self._final_states = [FinalEncoderState(h[-1], c[-1])]
     return ExpressionSequence(expr_list=h[1:], mask=expr_seq[0].mask)
 

--- a/xnmt/retriever.py
+++ b/xnmt/retriever.py
@@ -7,10 +7,11 @@ import os
 from lxml import etree
 
 import xnmt.batcher
-from xnmt.decorators import recursive, recursive_assign
+from xnmt.decorators import recursive_assign
 from xnmt.model import GeneratorModel
 from xnmt.serializer import Serializable
 from xnmt.reports import Reportable
+from xnmt.expression_sequence import ExpressionSequence
 
 ##### A class for retrieval databases
 # This file contains databases used for retrieval.
@@ -103,7 +104,7 @@ class DotProductRetriever(Retriever, Serializable, Reportable):
 
   def exprseq_pooling(self, exprseq):
     # Reduce to vector
-    exprseq.apply_additive_mask(-1e10)
+    exprseq = ExpressionSequence(expr_tensor=exprseq.mask.add_to_tensor_expr(exprseq.as_tensor(),-1e10), mask=exprseq.mask)
     if exprseq.expr_tensor != None:
       if len(exprseq.expr_tensor.dim()[0]) > 1:
         return dy.max_dim(exprseq.expr_tensor, d=1)

--- a/xnmt/translator.py
+++ b/xnmt/translator.py
@@ -2,7 +2,6 @@ from __future__ import division, generators
 
 import six
 import plot
-import os
 import dynet as dy
 import numpy as np
 
@@ -19,7 +18,6 @@ from xnmt.decorators import recursive_assign, recursive
 import xnmt.serializer
 import xnmt.evaluator
 from xnmt.batcher import mark_as_batch, is_batched
-from xnmt.vocab import Vocab
 
 # Reporting purposes
 from lxml import etree
@@ -30,13 +28,11 @@ class Translator(GeneratorModel):
   loss and generate translations.
   '''
 
-  def calc_loss(self, src, trg, src_mask=None, trg_mask=None):
+  def calc_loss(self, src, trg):
     '''Calculate loss based on input-output pairs.
 
     :param src: The source, a sentence or a batch of sentences.
     :param trg: The target, a sentence or a batch of sentences.
-    :param src_mask: A numpy array specifying the masking over the source, where rows are time steps, and columns are batch IDs.
-    :param trg_mask: A numpy array specifying the masking over the target, where rows are time steps, and columns are batch IDs.
     :returns: An expression representing the loss.
     '''
     raise NotImplementedError('calc_loss must be implemented for Translator subclasses')
@@ -111,22 +107,20 @@ class DefaultTranslator(Translator, Serializable, Reportable):
     self.report_path = kwargs.get("report_path", None)
     self.report_type = kwargs.get("report_type", None)
 
-  def calc_loss(self, src, trg, src_mask=None, trg_mask=None, info=None, loss='mle'):
+  def calc_loss(self, src, trg):
     """
     :param src: source sequence (unbatched, or batched + padded)
-    :param trg: target sequence (unbatched, or batched + padded)
-    :param src_mask: binary mask denoting src padding, passed to embedder
-    :param trg_mask: binary mask denoting trg padding; losses will be accumulated only if trg_mask[batch,pos]==0
+    :param trg: target sequence (unbatched, or batched + padded); losses will be accumulated only if trg_mask[batch,pos]==0, or no mask is set
     :returns: (possibly batched) loss expression
     """
     self.start_sent()
-    embeddings = self.src_embedder.embed_sent(src, mask=src_mask)
+    embeddings = self.src_embedder.embed_sent(src)
     encodings = self.encoder.transduce(embeddings)
     self.attender.init_sent(encodings)
     # Initialize the hidden state from the encoder
     ss = mark_as_batch([Vocab.SS] * len(src)) if is_batched(src) else Vocab.SS
     self.decoder.initialize(self.encoder.get_final_states(), self.trg_embedder.embed(ss))
-    return self.loss_calculator(self, src, trg, src_mask, trg_mask)
+    return self.loss_calculator(self, src, trg)
 
   def generate(self, src, idx, src_mask=None, forced_trg_ids=None):
     if not xnmt.batcher.is_batched(src):
@@ -136,7 +130,7 @@ class DefaultTranslator(Translator, Serializable, Reportable):
     outputs = []
     for sents in src:
       self.start_sent()
-      embeddings = self.src_embedder.embed_sent(src, mask=src_mask)
+      embeddings = self.src_embedder.embed_sent(src)
       encodings = self.encoder.transduce(embeddings)
       self.attender.init_sent(encodings)
       ss = mark_as_batch([Vocab.SS] * len(src)) if is_batched(src) else Vocab.SS
@@ -215,13 +209,14 @@ class DefaultTranslator(Translator, Serializable, Reportable):
 class TranslatorMLELoss(Serializable):
   yaml_tag = '!TranslatorMLELoss'
 
-  def __call__(self, translator, src, trg, src_mask, trg_mask):
+  def __call__(self, translator, src, trg):
+    trg_mask = trg.mask if xnmt.batcher.is_batched(trg) else None
     losses = []
     seq_len = len(trg[0]) if xnmt.batcher.is_batched(src) else len(trg)
     if xnmt.batcher.is_batched(src):
       for j, single_trg in enumerate(trg):
         assert len(single_trg) == seq_len # assert consistent length
-        assert 1==len([i for i in range(seq_len) if (trg_mask is None or trg_mask[j,i]==0) and single_trg[i]==Vocab.ES]) # assert exactly one unmasked ES token
+        assert 1==len([i for i in range(seq_len) if (trg_mask is None or trg_mask.np_arr[j,i]==0) and single_trg[i]==Vocab.ES]) # assert exactly one unmasked ES token
     for i in range(seq_len):
       ref_word = trg[i] if not xnmt.batcher.is_batched(src) \
                       else xnmt.batcher.mark_as_batch([single_trg[i] for single_trg in trg])
@@ -229,7 +224,7 @@ class TranslatorMLELoss(Serializable):
       context = translator.attender.calc_context(translator.decoder.state.output())
       word_loss = translator.decoder.calc_loss(context, ref_word)
       if xnmt.batcher.is_batched(src) and trg_mask is not None:
-        mask_exp = dy.inputTensor((1.0 - trg_mask)[:,i:i+1].transpose(),batched=True)
+        mask_exp = dy.inputTensor((1.0 - trg_mask.np_arr)[:,i:i+1].transpose(),batched=True)
         word_loss = word_loss * mask_exp
       losses.append(word_loss)
       if i < seq_len-1:
@@ -247,7 +242,8 @@ class TranslatorReinforceLoss(Serializable):
     else:
       self.evaluation_metric = evaluation_metric
 
-  def __call__(self, translator, src, trg, src_mask, trg_mask):
+  def __call__(self, translator, src, trg):
+    # TODO: apply trg.mask ?
     samples = []
     logsofts = []
     done = [False for _ in range(len(trg))]

--- a/xnmt/translator.py
+++ b/xnmt/translator.py
@@ -224,8 +224,7 @@ class TranslatorMLELoss(Serializable):
       context = translator.attender.calc_context(translator.decoder.state.output())
       word_loss = translator.decoder.calc_loss(context, ref_word)
       if xnmt.batcher.is_batched(src) and trg_mask is not None:
-        mask_exp = dy.inputTensor((1.0 - trg_mask.np_arr)[:,i:i+1].transpose(),batched=True)
-        word_loss = word_loss * mask_exp
+        word_loss = trg_mask.cmult_by_timestep_expr(word_loss, i, inverse=True)
       losses.append(word_loss)
       if i < seq_len-1:
         translator.decoder.add_input(translator.trg_embedder.embed(ref_word))


### PR DESCRIPTION
This is to make it easier for batch masks to be passed on between the different modules:
- there is a new Mask class, including code to apply that mask to dynet expressions to reduce code duplication
- masks are now stored and passed on as attributes of Batch or ExpressionSequence objects, and never explicitly
- to make ExpressionSequences immutable per convention, so we don't have to worry about side effects, masks no longer modify the expression inside an ExpressionSequence, but create a new ExpressionSequence instead