### PR TITLE
Minor Tweaks in TranslatorReinforceLoss

### DIFF
--- a/xnmt/cython/src/functions.h
+++ b/xnmt/cython/src/functions.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <iostream>
+#include <vector>
 
 namespace xnmt {
 

--- a/xnmt/translator.py
+++ b/xnmt/translator.py
@@ -265,9 +265,14 @@ class TranslatorReinforceLoss(Serializable):
     for trg_i, sample_i in zip(trg, samples):
       # Removing EOS
       try:
-        idx = next(word for word in sample_i if word == Vocab.ES)
+        idx = sample_i.index(Vocab.ES)
         sample_i = sample_i[:idx]
-      except StopIteration:
+      except ValueError:
+        pass
+      try:
+        idx = trg_i.words.index(Vocab.ES)
+        trg_i.words = trg_i.words[:idx]
+      except ValueError:
         pass
       # Calculate the evaluation score
       eval_score.append(self.evaluation_metric.evaluate_fast(trg_i.words, sample_i))


### PR DESCRIPTION
For some reason, next() doesn't seem to work as expected. I am unable to reason why and if it is just for me.
**Earlier:**
Predicted Sentence (before using next()) :     
`  they have each dealer , i don &apos;t know what else they start doing because , i see , there are , lots of people that for example , my mom is already , uh , she took to five calls </s> </s> </s> </s> </s> </s> </s>   `
 Reference Sentence (before using next()) :        
  `have every person . therefore , i don &apos;t know what they are going to do . because , already , already are a to much people that , by example , my mother <unk> have reach the twenty five calls </s> </s> </s> </s> </s>  ` 
Predicted Sentence (after using next()):     
`      they   `
Reference Sentence (after using next()):      
`     have   `
`   BLEU score 0.0   `


**After changing next() by index():**
Predicted Sentence (before using index()) :     
`  ah , okay . </s> `
 Reference Sentence (before using index()) :        
  `oh , okay  </s>` 
Predicted Sentence (after using index()):     
`      ah , okay .     `
Reference Sentence (after using index()):      
`     oh , okay    `
`   BLEU score 0.4518010018049224   `

It might be an overkill to segment reference sentence every time though. Might not be required.