### PR TITLE
Made the decoder stateless again

### DIFF
--- a/xnmt/decoder.py
+++ b/xnmt/decoder.py
@@ -30,6 +30,12 @@ class RnnDecoder(Decoder):
     else:
       raise RuntimeError("Unknown decoder type {}".format(spec))
 
+class MlpSoftmaxDecoderState:
+  """A state holding all the information needed for MLPSoftmaxDecoder"""
+  def __init__(self, rnn_state=None, context=None):
+    self.rnn_state = rnn_state
+    self.context = context
+
 class MlpSoftmaxDecoder(RnnDecoder, Serializable):
   # TODO: This should probably take a softmax object, which can be normal or class-factored, etc.
   # For now the default behavior is hard coded.
@@ -38,7 +44,7 @@ class MlpSoftmaxDecoder(RnnDecoder, Serializable):
 
   def __init__(self, context, vocab_size, layers=1, input_dim=None, lstm_dim=None,
                mlp_hidden_dim=None, trg_embed_dim=None, dropout=None,
-               rnn_spec="lstm", residual_to_output=False, input_feeding=False,
+               rnn_spec="lstm", residual_to_output=False, input_feeding=True,
                bridge=None):
     param_col = context.dynet_param_collection.param_col
     # Define dim
@@ -72,45 +78,48 @@ class MlpSoftmaxDecoder(RnnDecoder, Serializable):
                                          model = param_col)
     # Dropout
     self.dropout = dropout or context.dropout
-    # Mutable state
-    self.state = None
-    self.h_t = None
 
   def shared_params(self):
     return [set(["layers", "bridge.dec_layers"]),
             set(["lstm_dim", "bridge.dec_dim"])]
 
-  def get_state(self):
-    return (self.state, self.h_t)
+  def initial_state(self, enc_final_states, ss_expr):
+    """Get the initial state of the decoder given the encoder final states.
 
-  def set_state(self, params):
-    self.state, self.h_t = params
+    :param enc_final_states: The encoder final states.
+    :returns: An MlpSoftmaxDecoderState
+    """
+    rnn_state = self.fwd_lstm.initial_state()
+    rnn_state = rnn_state.set_s(self.bridge.decoder_init(enc_final_states))
+    # TODO: This is commented out because it has inconsistent dimension for now
+    # rnn_state = rnn_state.add_input(ss_expr)
+    zeros = dy.zeros(self.lstm_dim) if self.input_feeding else None
+    return MlpSoftmaxDecoderState(rnn_state=rnn_state, context=zeros)
 
-  def initialize(self, enc_final_states, ss_expr):
-    dec_state = self.fwd_lstm.initial_state()
-    self.state = dec_state.set_s(self.bridge.decoder_init(enc_final_states))
-    self.h_t = None
-    self.add_input(ss_expr)
+  def add_input(self, mlp_dec_state, trg_embedding):
+    """Add an input and update the state.
 
-  def add_input(self, trg_embedding):
+    :param mlp_dec_state: An MlpSoftmaxDecoderState object containing the current state.
+    :param trg_embedding: The embedding of the word to input.
+    :returns: The update MLP decoder state.
+    """
     inp = trg_embedding
     if self.input_feeding:
-      if self.h_t is not None:
-        # Append with the last state of the decoder
-        inp = dy.concatenate([inp, self.h_t])
-      else:
-        # Append with zero
-        zero = dy.zeros(self.lstm_dim, batch_size=inp.dim()[1])
-        inp = dy.concatenate([inp, zero])
-    # The next state of the decoder
-    self.state = self.state.add_input(inp)
+      inp = dy.concatenate([inp, mlp_dec_state.context])
+    return MlpSoftmaxDecoderState(rnn_state=mlp_dec_state.rnn_state.add_input(inp),
+                                  context=mlp_dec_state.context)
 
-  def get_scores(self, context):
-    self.h_t = dy.tanh(self.context_projector(dy.concatenate([context, self.state.output()])))
-    return self.vocab_projector(self.h_t)
+  def get_scores(self, mlp_dec_state):
+    """Get scores given a current state.
 
-  def calc_loss(self, context, ref_action):
-    scores = self.get_scores(context)
+    :param mlp_dec_state: An MlpSoftmaxDecoderState object.
+    :returns: Scores over the vocabulary given this state.
+    """
+    h_t = dy.tanh(self.context_projector(dy.concatenate([mlp_dec_state.rnn_state.output(), mlp_dec_state.context])))
+    return self.vocab_projector(h_t)
+
+  def calc_loss(self, mlp_dec_state, ref_action):
+    scores = self.get_scores(mlp_dec_state)
     # single mode
     if not xnmt.batcher.is_batched(ref_action):
       return dy.pickneglogsoftmax(scores, ref_action)

--- a/xnmt/search_strategy.py
+++ b/xnmt/search_strategy.py
@@ -56,11 +56,12 @@ class BeamSearch(SearchStrategy):
     def __repr__(self):
       return "hypo S=%s |ids|=%s" % (self.score, len(self.id_list))
 
-  def generate_output(self, decoder, attender, output_embedder, src_length=None, forced_trg_ids=None):
+  def generate_output(self, decoder, attender, output_embedder, dec_state, src_length=None, forced_trg_ids=None):
     """
     :param decoder: decoder.Decoder subclass
     :param attender: attender.Attender subclass
     :param output_embedder: embedder.Embedder subclass
+    :param dec_state: The decoder state
     :param src_length: length of src sequence, required for some types of length normalization
     :param forced_trg_ids: list of word ids, if given will force to generate this is the target sequence
     :returns: (id list, score)
@@ -68,7 +69,7 @@ class BeamSearch(SearchStrategy):
 
     if forced_trg_ids is not None: assert self.beam_size == 1
 
-    active_hyp = [self.Hypothesis(0, [], decoder.get_state())]
+    active_hyp = [self.Hypothesis(0, [], dec_state)]
 
     completed_hyp = []
     length = 0
@@ -77,14 +78,14 @@ class BeamSearch(SearchStrategy):
       new_set = []
       for hyp in active_hyp:
 
-        decoder.set_state(hyp.state)
+        dec_state = hyp.state
         if length > 0: # don't feed in the initial start-of-sentence token
           if hyp.id_list[-1] == Vocab.ES:
             completed_hyp.append(hyp)
             continue
-          decoder.add_input(output_embedder.embed(hyp.id_list[-1] if forced_trg_ids is None else forced_trg_ids[length-1]))
-        context = attender.calc_context(decoder.state.output())
-        score = dy.log_softmax(decoder.get_scores(context)).npvalue()
+          dec_state = decoder.add_input(dec_state, output_embedder.embed(hyp.id_list[-1] if forced_trg_ids is None else forced_trg_ids[length-1]))
+        dec_state.context = attender.calc_context(dec_state.rnn_state.output())
+        score = dy.log_softmax(decoder.get_scores(dec_state)).npvalue()
         if forced_trg_ids is None:
           top_ids = np.argpartition(score, max(-len(score),-self.beam_size))[-self.beam_size:]
         else:
@@ -95,7 +96,7 @@ class BeamSearch(SearchStrategy):
           new_list.append(cur_id)
           new_set.append(self.Hypothesis(self.len_norm.normalize_partial(hyp.score, score[cur_id], len(new_list)),
                                          new_list,
-                                         decoder.get_state()))
+                                         dec_state))
       length += 1
 
       active_hyp = sorted(new_set, key=lambda x: x.score, reverse=True)[:self.beam_size]

--- a/xnmt/translator.py
+++ b/xnmt/translator.py
@@ -135,7 +135,7 @@ class DefaultTranslator(Translator, Serializable, Reportable):
       self.attender.init_sent(encodings)
       ss = mark_as_batch([Vocab.SS] * len(src)) if is_batched(src) else Vocab.SS
       dec_state = self.decoder.initial_state(self.encoder.get_final_states(), self.trg_embedder.embed(ss))
-      output_actions, score = self.search_strategy.generate_output(self.decoder, self.attender, self.trg_embedder, src_length=len(sents), forced_trg_ids=forced_trg_ids)
+      output_actions, score = self.search_strategy.generate_output(self.decoder, self.attender, self.trg_embedder, dec_state, src_length=len(sents), forced_trg_ids=forced_trg_ids)
       # In case of reporting
       if self.report_path is not None:
         src_words = [self.reporting_src_vocab[w] for w in sents]


### PR DESCRIPTION
This is a second attempt at https://github.com/neulab/xnmt/pull/194

This commit makes the decoder stateless, removing any of its global variables and instead holding them in a separate state object. This will probably reduce potential for bugs in search algorithms, etc.

Also, input feeding is put on by default. It also makes a change to input feeding, feeding in the context, not the hidden layer of the MLP. It might be worth feeding in the hidden layer of the MLP instead, but I don't think this is the standard way of doing things (as noted by @cindyxinyiwang )