### PR TITLE
[WIP] Fix length normalization when evaluating on dev set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__
 *.swp
 *.pyc
 *.so
+.idea
 examples/output
 doc/build
 xnmt.egg-info

--- a/test/config/standard.yaml
+++ b/test/config/standard.yaml
@@ -1,0 +1,43 @@
+# A standard training run, should almost never break
+defaults:
+  experiment:
+    model_file: examples/output/<EXP>.mod
+    hyp_file: examples/output/<EXP>.hyp
+    out_file: examples/output/<EXP>.out
+    err_file: examples/output/<EXP>.err
+    run_for_epochs: 2
+    eval_metrics: bleu,wer
+  train:
+    dev_metrics: bleu
+    default_layer_dim: 32
+    training_corpus: !BilingualTrainingCorpus
+      train_src: examples/data/head.ja
+      train_trg: examples/data/head.en
+      dev_src: examples/data/head.ja
+      dev_trg: examples/data/head.en
+    corpus_parser: !BilingualCorpusParser
+      src_reader: !PlainTextReader {}
+      trg_reader: !PlainTextReader {}
+    model: !DefaultTranslator
+      src_embedder: !SimpleWordEmbedder
+        emb_dim: 64
+      encoder: !LSTMEncoder
+        layers: 1
+      attender: !StandardAttender
+        state_dim: 64
+        hidden_dim: 64
+        input_dim: 64
+      trg_embedder: !SimpleWordEmbedder
+        emb_dim: 64
+      decoder: !MlpSoftmaxDecoder
+        layers: 1
+        bridge: !CopyBridge {}
+  decode:
+    len_norm_type: !PolynomialNormalization
+      apply_during_search: true
+      m: 1
+    src_file: examples/data/head.ja
+  evaluate:
+    ref_file: examples/data/head.en
+
+standard:

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -6,6 +6,9 @@ import xnmt.xnmt_run_experiments as run
 
 class TestRunningConfig(unittest.TestCase):
 
+  def test_standard_run(self):
+    run.main(["test/config/standard.yaml"])
+
   def test_random_search_test_params(self):
     run.main(["test/config/random_search_test_params.yaml"])
 


### PR DESCRIPTION
Currently it seems that activating length normalization will cause crashing on the second epoch when evaluating on the dev set. This adds a unit test to demonstrate the breakage with the following error:

     Start training in minibatch mode...   
     Epoch 1.0000: train_loss/word=3.066 (words=140, words/sec=5200.58, time=0-00:00:00)   
     initialized PolynomialNormalization({'apply_during_search': True, 'm': 1})   
     > Checkpoint   
       Epoch 1.0000 dev [auxiliary] BLEU4: 0   
       Epoch 1.0000 dev Loss: 2.994 (words=140, words/sec=4514.20, time=0-00:00:00)   
       Epoch 1.0000: best dev score, writing model to examples/output/standard.mod   
     Epoch 2.0000: train_loss/word=2.994 (words=140, words/sec=1628.74, time=0-00:00:00)   
     Traceback (most recent call last):
       File "xnmt/xnmt_run_experiments.py", line 166, in <module>
            sys.exit(main())   
       File "xnmt/xnmt_run_experiments.py", line 127, in main
            xnmt_trainer.run_epoch()   
       File "/Users/neubig/work/xnmt/xnmt/xnmt_train.py", line 245, in run_epoch
            self.dev_evaluation()   
       File "/Users/neubig/work/xnmt/xnmt/xnmt_train.py", line 264, in dev_evaluation
            xnmt.xnmt_decode.xnmt_decode(self.decode_args, model_elements=(self.corpus_parser, self.model))   
       File "/Users/neubig/work/xnmt/xnmt/xnmt_decode.py", line 70, in xnmt_decode
            generator.initialize_generator(**args.params_as_dict)   
       File "/Users/neubig/work/xnmt/xnmt/translator.py", line 98, in initialize_generator
            len_norm = xnmt.serializer.YamlSerializer().initialize_object(kwargs["len_norm_type"])   
       File "/Users/neubig/work/xnmt/xnmt/serializer.py", line 51, in initialize_object
            self.set_serialize_params_recursive(deserialized_yaml)   
       File "/Users/neubig/work/xnmt/xnmt/serializer.py", line 79, in set_serialize_params_recursive
            raise ValueError("unknown init parameter for %s: %s" % (obj.yaml_tag, name))   
     ValueError   :    unknown init parameter for !PolynomialNormalization: context   

I'm not sure the cause of this, but perhaps it's related to argument parsing? Any ideas @msperber or @psjanani ?