### PR TITLE
Fix word batcher & configure via avg_batch_size

### DIFF
--- a/examples/standard.yaml
+++ b/examples/standard.yaml
@@ -9,7 +9,7 @@ defaults:
     eval_metrics: bleu
   train:
     batcher: !WordSrcBatcher
-      words_per_batch: 1
+      avg_batch_size: 10
     dropout: 0.1
     default_layer_dim: 512
     restart_trainer: True

--- a/examples/standard.yaml
+++ b/examples/standard.yaml
@@ -8,8 +8,8 @@ defaults:
     run_for_epochs: 20
     eval_metrics: bleu
   train:
-    batcher: !SrcBatcher
-      batch_size: 10
+    batcher: !WordSrcBatcher
+      words_per_batch: 1
     dropout: 0.1
     default_layer_dim: 512
     restart_trainer: True


### PR DESCRIPTION
- Fix a crash in word batcher when words_per_batch was smaller than the largest sentence length
- Alternatively to words_per_batch, configure word batcher via avg_batch_size, which might be more intuitive to use