### PR TITLE
Fixed a bug counting padding symbols for PPL

### DIFF
--- a/xnmt/decoder.py
+++ b/xnmt/decoder.py
@@ -120,7 +120,12 @@ class MlpSoftmaxDecoder(RnnDecoder, Serializable):
 
   def calc_loss(self, mlp_dec_state, ref_action):
     scores = self.get_scores(mlp_dec_state)
-    return dy.pickneglogsoftmax_batch(scores, ref_action)
+    # single mode     
+    if not xnmt.batcher.is_batched(ref_action):   
+      return dy.pickneglogsoftmax(scores, ref_action)   
+    # minibatch mode    
+    else:   
+      return dy.pickneglogsoftmax_batch(scores, ref_action)
 
   @handle_xnmt_event
   def on_set_train(self, val):

--- a/xnmt/decoder.py
+++ b/xnmt/decoder.py
@@ -120,12 +120,7 @@ class MlpSoftmaxDecoder(RnnDecoder, Serializable):
 
   def calc_loss(self, mlp_dec_state, ref_action):
     scores = self.get_scores(mlp_dec_state)
-    # single mode
-    if not xnmt.batcher.is_batched(ref_action):
-      return dy.pickneglogsoftmax(scores, ref_action)
-    # minibatch mode
-    else:
-      return dy.pickneglogsoftmax_batch(scores, ref_action)
+    return dy.pickneglogsoftmax_batch(scores, ref_action)
 
   @handle_xnmt_event
   def on_set_train(self, val):

--- a/xnmt/loss_tracker.py
+++ b/xnmt/loss_tracker.py
@@ -4,6 +4,7 @@ import sys
 import math
 import time
 import xnmt.loss
+from xnmt.vocab import Vocab
 
 class LossTracker(object):
   """
@@ -164,7 +165,13 @@ class BatchLossTracker(LossTracker):
   """
 
   def count_trg_words(self, trg_words):
-    return sum((1 if type(x) == int else len(x)) for x in trg_words)
+    trg_cnt = 0
+    for x in trg_words:
+      if type(x) == int:
+        trg_cnt += 1 if x != Vocab.ES else 0
+      else:
+        trg_cnt += sum([1 if y != Vocab.ES else 0 for y in x])
+    return trg_cnt
 
   def count_sent_num(self, obj):
     return len(obj)

--- a/xnmt/xnmt_train.py
+++ b/xnmt/xnmt_train.py
@@ -330,11 +330,11 @@ class XnmtTrainer(object):
   def compute_dev_loss(self):
     loss_builder = LossBuilder()
     trg_words_cnt = 0
-    for i in range(len(self.dev_src)):
+    for src, trg in zip(self.dev_src, self.dev_trg):
       dy.renew_cg()
-      standard_loss = self.model.calc_loss(self.dev_src[i], self.dev_trg[i])
+      standard_loss = self.model.calc_loss(src, trg)
       loss_builder.add_loss("loss", standard_loss)
-      trg_words_cnt += self.logger.count_trg_words(self.dev_trg[i])
+      trg_words_cnt += self.logger.count_trg_words(trg)
       loss_builder.compute()
     return trg_words_cnt, LossScore(loss_builder.sum() / trg_words_cnt)
 


### PR DESCRIPTION
This fixes a bug that was counting padding symbols in the denominator when calculating PPL. Now the word count matches the actual number of words included in the file (as measured by `wc`).

Note, this change won't affect your BLEU scores, but it has the potential to have a *large effect* on your perplexity/loss scores. Please be aware of it if you're reporting perplexity scores in your experiments, or comparing with other toolkits.