### PR TITLE
implement SerialMultiTaskTrainingRegimen + fixes

### DIFF
--- a/test/config/multi_task.yaml
+++ b/test/config/multi_task.yaml
@@ -7,7 +7,7 @@ multi_task_exp:
     out_file: examples/output/<EXP>.out
     err_file: examples/output/<EXP>.err
     eval_metrics: bleu,wer
-  train: !JointMultiTaskTrainingRegimen
+  train: !SameBatchMultiTaskTrainingRegimen
     trainer: !AdamTrainer {}
     tasks:
     - !SimpleTrainingTask # first task is the main task: it will control early stopping, learning rate schedule, model checkpoints, ..

--- a/xnmt/training_regimen.py
+++ b/xnmt/training_regimen.py
@@ -29,10 +29,8 @@ from xnmt.retriever import *
 from xnmt.corpus import *
 from xnmt.segmenting_encoder import *
 from xnmt.optimizer import SimpleSGDTrainer
-from xnmt.loss_calculator import LossCalculator, MLELoss
 from xnmt.serializer import YamlSerializer, Serializable
 from xnmt.inference import SimpleInference
-import xnmt.xnmt_evaluate
 import xnmt.optimizer
 from xnmt.training_task import SimpleTrainingTask
 
@@ -47,6 +45,18 @@ class TrainingRegimen(object):
     :param update_weights: Whether parameters should be updated
     """
     raise NotImplementedError("")
+  def update_weights(self, loss, trainer, dynet_profiling):
+    """
+    Standardized way to perform backward pass and parameter updates.
+    
+    :param loss: Result of self.training_step(...)
+    :param trainer: DyNet trainer / xnmt.optimizer object
+    :param dynet_profiling: if > 0, print the computation graph 
+    """
+    if dynet_profiling and dynet_profiling > 0:
+      dy.print_text_graphviz()
+    loss.backward()
+    trainer.update()
 
 class SimpleTrainingRegimen(SimpleTrainingTask, TrainingRegimen, Serializable):
   yaml_tag = u'!SimpleTrainingRegimen'
@@ -144,6 +154,7 @@ class MultiTaskTrainingRegimen(TrainingRegimen):
     self.train = None
     self.yaml_serializer = YamlSerializer()
     self.model_file = yaml_context.dynet_param_collection.model_file
+    self.main_task = 0
   def trigger_train_event(self, value):
     """
     Trigger set_train event, but only if that would lead to a change of the value
@@ -152,7 +163,7 @@ class MultiTaskTrainingRegimen(TrainingRegimen):
     """
     if self.train is None:
       self.train = value
-      self.tasks[0].model.set_train(value)
+      self.tasks[0].model.set_train(value) # tasks[0] is arbitrary; will invoke on_set_train() for all models
     else:
       if value!=self.train:
         self.train = value
@@ -162,23 +173,29 @@ class MultiTaskTrainingRegimen(TrainingRegimen):
     """
     Allow access to corpus_parser of main task
     """
-    return self.tasks[0].corpus_parser
+    return self.tasks[self.main_task].corpus_parser
   @property
   def model(self):
     """
     Allow access to model of main task
     """
-    return self.tasks[0].model
+    return self.tasks[self.main_task].model
+  @property
+  def batcher(self):
+    """
+    Allow access to batcher of main task
+    """
+    return self.tasks[self.main_task].batcher
 
-class JointMultiTaskTrainingRegimen(MultiTaskTrainingRegimen, Serializable):
-  yaml_tag = u"!JointMultiTaskTrainingRegimen"
+class SameBatchMultiTaskTrainingRegimen(MultiTaskTrainingRegimen, Serializable):
+  yaml_tag = u"!SameBatchMultiTaskTrainingRegimen"
   """
   Multi-task training where gradients are accumulated and weight updates
   are thus performed jointly for each task. The relative weight between
   tasks can be configured by setting each tasks batch size accordingly.
   """
   def __init__(self, yaml_context, tasks, trainer=None, dynet_profiling=0):
-    super(JointMultiTaskTrainingRegimen, self).__init__(yaml_context,
+    super(SameBatchMultiTaskTrainingRegimen, self).__init__(yaml_context,
                                                  tasks=tasks, trainer=trainer,
                                                  dynet_profiling=dynet_profiling)
     self.yaml_context = yaml_context
@@ -206,8 +223,8 @@ class JointMultiTaskTrainingRegimen(MultiTaskTrainingRegimen, Serializable):
       if self.tasks[0].should_stop_training(): break
   
 
-class SerialMultiTaskTrainingRegimen(MultiTaskTrainingRegimen, Serializable):
-  yaml_tag = u"!SerialMultiTaskTrainingRegimen"
+class AlternatingBatchMultiTaskTrainingRegimen(MultiTaskTrainingRegimen, Serializable):
+  yaml_tag = u"!AlternatingBatchMultiTaskTrainingRegimen"
   """
   Multi-task training where training steps are performed one after another.
   The relative weight between tasks are explicitly specified explicitly, and for
@@ -217,7 +234,7 @@ class SerialMultiTaskTrainingRegimen(MultiTaskTrainingRegimen, Serializable):
   tasks by setting the task weight to 0.
   """
   def __init__(self, yaml_context, tasks, task_weights=None, trainer=None, dynet_profiling=0):
-    super(SerialMultiTaskTrainingRegimen, self).__init__(yaml_context,
+    super(AlternatingBatchMultiTaskTrainingRegimen, self).__init__(yaml_context,
                                                   tasks=tasks, trainer=trainer,
                                                   dynet_profiling=dynet_profiling)
     self.task_weights = task_weights or [1./len(tasks)] * len(tasks) 
@@ -245,3 +262,43 @@ class SerialMultiTaskTrainingRegimen(MultiTaskTrainingRegimen, Serializable):
       self.trigger_train_event(update_weights)
       if self.tasks[0].should_stop_training(): break
 
+class SerialMultiTaskTrainingRegimen(MultiTaskTrainingRegimen, Serializable):
+  """
+  Trains only first task until stopping criterion met, then the same for the
+  second task, etc.
+  
+  Useful to realize a pretraining-finetuning strategy.
+  """
+
+  yaml_tag = u"!SerialTrainingRegimen"
+  
+  def __init__(self, yaml_context, tasks, trainer=None, dynet_profiling=0):
+    """
+    :param tasks: list of TrainingTask instances. The currently active task is treated as main task.
+    :param trainer: Trainer object, default is SGD with learning rate 0.1
+    :param dynet_profiling: if > 0, print computation graph
+    """
+    super(SerialMultiTaskTrainingRegimen, self).__init__(yaml_context,
+                                                  tasks=tasks, trainer=trainer,
+                                                  dynet_profiling=dynet_profiling)
+    self.yaml_context = yaml_context
+  def run_training(self, update_weights=True):
+    for cur_task_id in range(len(self.tasks)):
+      self.main_task = cur_task_id
+      self.train = None
+      cur_task = self.tasks[cur_task_id]
+      task_gen = cur_task.next_minibatch()
+      self.trigger_train_event(update_weights)
+      while True:
+        src, trg = next(task_gen)
+        task_loss = cur_task.training_step(src, trg)
+        if update_weights:
+          self.update_weights(task_loss, self.trainer, self.dynet_profiling)
+        if cur_task.checkpoint_needed():
+          self.trigger_train_event(False)
+          should_save = cur_task.checkpoint(control_learning_schedule = True)
+          if should_save:
+            self.yaml_serializer.save_to_file(self.model_file, self,
+                                              self.yaml_context.dynet_param_collection)
+        self.trigger_train_event(update_weights)
+        if cur_task.should_stop_training(): break

--- a/xnmt/training_task.py
+++ b/xnmt/training_task.py
@@ -44,20 +44,6 @@ class TrainingTask(object):
     """
     raise NotImplementedError("")
 
-  def update_weights(self, loss, trainer, dynet_profiling):
-    """
-    Standardized way to perform backward pass and parameter updates.
-    Can be sidestepped e.g. for custom multitask training logic.
-    
-    :param loss: Result of self.training_step(...)
-    :param trainer: DyNet trainer / xnmt.optimizer object
-    :param dynet_profiling: if > 0, print the computation graph 
-    """
-    if dynet_profiling and dynet_profiling > 0:
-      dy.print_text_graphviz()
-    loss.backward()
-    trainer.update()
-  
   def checkpoint_needed(self):
     raise NotImplementedError()
 


### PR DESCRIPTION
- implemented ```SerialMultiTaskTrainingRegimen``` which trains task 1 to convergence, then task 2, etc. (useful for pretraining/finetuning)
- fixed some things I broke when refactoring yesterday
- improved naming (let me know if you have other naming suggestions):
  - ```SimpleTrainingRegimen``` (unchanged)
  - ```SameBatchMultiTaskTrainingRegimen``` (previously ```JointMultiTaskTrainingRegimen```)
  - ```AlternatingBatchMultiTaskTrainingRegimen``` (previously ```SerialMultiTaskTrainingRegimen```)
  - ```SerialMultiTaskTrainingRegimen``` (new)