### PR TITLE
make sentpiece model dir; fix stderr preproc output

### DIFF
--- a/xnmt/preproc.py
+++ b/xnmt/preproc.py
@@ -232,7 +232,7 @@ class SentencepieceTokenizer(ExternalTokenizer):
       try:
         os.makedirs(os.path.dirname(model_prefix))
       except OSError as exc:
-        if exc.errno != errno.EEXist:
+        if exc.errno != errno.EEXIST:
           raise
 
     if ((not os.path.exists(self.model_prefix + '.model')) or


### PR DESCRIPTION
- sentencepiece models weren't being built for me on a clean install because the `preproc` folder wasn't being made before sentencepiece was initialized. 
 - This error was being hidden because stderr messages were only being written given an unrelated condition.
This PR fixes those bugs for Python 3.6. Python 2 should work but no promises. 