### PR TITLE
add general linear attender of https://arxiv.org/abs/1508.04025

### DIFF
--- a/xnmt/attender.py
+++ b/xnmt/attender.py
@@ -105,12 +105,12 @@ class DotAttender(Attender, Serializable):
     I = self.curr_sent.as_tensor()
     return I * attention
 
-class GeneralLinearAttender(Attender, Serializable):
+class BilinearAttender(Attender, Serializable):
   '''
   Implements the general linear attention of https://arxiv.org/abs/1508.04025
   '''
 
-  yaml_tag = u'!GeneralLinearAttender'
+  yaml_tag = u'!BilinearAttender'
 
   def __init__(self, yaml_context, input_dim=None, state_dim=None):
     input_dim = input_dim or yaml_context.default_layer_dim

--- a/xnmt/attender.py
+++ b/xnmt/attender.py
@@ -107,7 +107,8 @@ class DotAttender(Attender, Serializable):
 
 class BilinearAttender(Attender, Serializable):
   '''
-  Implements the general linear attention of https://arxiv.org/abs/1508.04025
+  Implements a bilinear attention, equivalent to the 'general' linear
+  attention of https://arxiv.org/abs/1508.04025
   '''
 
   yaml_tag = u'!BilinearAttender'

--- a/xnmt/attender.py
+++ b/xnmt/attender.py
@@ -104,3 +104,36 @@ class DotAttender(Attender, Serializable):
     attention = self.calc_attention(state)
     I = self.curr_sent.as_tensor()
     return I * attention
+
+class GeneralLinearAttender(Attender, Serializable):
+  '''
+  Implements the general linear attention of https://arxiv.org/abs/1508.04025
+  '''
+
+  yaml_tag = u'!GeneralLinearAttender'
+
+  def __init__(self, yaml_context, input_dim=None, state_dim=None):
+    input_dim = input_dim or yaml_context.default_layer_dim
+    state_dim = state_dim or yaml_context.default_layer_dim
+    self.input_dim = input_dim
+    self.state_dim = state_dim
+    param_collection = yaml_context.dynet_param_collection.param_col
+    self.pWa = param_collection.add_parameters((input_dim, state_dim))
+    self.curr_sent = None
+
+  def init_sent(self, sent):
+    self.curr_sent = sent
+    self.attention_vecs = []
+    self.I = self.curr_sent.as_tensor()
+
+  def calc_attention(self, state):
+    Wa = dy.parameter(self.pWa)
+    scores = (dy.transpose(state) * Wa) * self.I
+    normalized = dy.softmax(scores)
+    self.attention_vecs.append(normalized)
+    return dy.transpose(normalized)
+
+  def calc_context(self, state):
+    attention = self.calc_attention(state)
+    return self.I * attention
+


### PR DESCRIPTION
The _general_ attender of https://arxiv.org/abs/1508.04025 is a nice compromise between the more complicated MlpAttender and the unparametrized DotAttender. It is implemented here.

## quick benchmarks on examples/data/{train,dev,test}.{ja,en}
Summary of below -- GeneralLinear seems to be at least on par, BLEU-wise, with the MLP. May be better, but I have my doubts. The improvement may be due to its having fewer parameters, since the train set is so small. It's also considerably slower, which is unintuitive to me, but maybe someone can rewrite line 131 

### MlpAttender
- train words/sec=2574.60ish
- Dev bleu 0.016222765483504837 (20 epochs)
- Test bleu 0.02349701978746616 (20 epochs)

### GeneralLinearAttender
 - train words/sec=1540.73ish
 - Dev bleu 0.031945032510106094 (20 epochs)
 - Test bleu 0.04681154243162295 (20 epochs)

