### PR TITLE
Better ref resolution, fix speech reporting

### DIFF
--- a/test/config/speech.yaml
+++ b/test/config/speech.yaml
@@ -28,7 +28,8 @@ speech-2layers: !Experiment
       transpose: True
     trg_reader: !PlainTextReader
       vocab: !Vocab {vocab_file: examples/data/head.en.vocab}
-    inference: !SimpleInference {}
+    inference: !SimpleInference
+      report_path: examples/output/report/
   train: !SimpleTrainingRegimen
     run_for_epochs: 1
     batcher: !SrcBatcher
@@ -49,6 +50,7 @@ speech-2layers: !Experiment
         hyp_file: examples/output/{EXP}.dev_hyp
         inference: !SimpleInference
           post_process: join-char
+          report_path: examples/output/report.{EXP}
   evaluate:
     - !AccuracyEvalTask
       eval_metrics: cer,wer

--- a/xnmt/serialize/serializer.py
+++ b/xnmt/serialize/serializer.py
@@ -198,15 +198,18 @@ class YamlSerializer(object):
     return initialized_obj
 
   def resolve_serialize_refs(self, root):
-    for _, node in tree_tools.traverse_serializable_breadth_first(root):
+#     for _, node in tree_tools.traverse_serializable_breadth_first(root):
+    for _, node in tree_tools.traverse_serializable(root):
       if isinstance(node, Serializable):
         node.resolved_serialize_params = node.serialize_params
     refs_inserted_at = set()
     refs_inserted_to = set()
-    for path_to, node in tree_tools.traverse_serializable_breadth_first(root):
+#     for path_to, node in tree_tools.traverse_serializable_breadth_first(root):
+    for path_to, node in tree_tools.traverse_serializable(root):
       if not refs_inserted_at & path_to.ancestors() and not refs_inserted_at & path_to.ancestors():
         if isinstance(node, Serializable):
-          for path_from, matching_node in tree_tools.traverse_serializable_breadth_first(root):
+#           for path_from, matching_node in tree_tools.traverse_serializable_breadth_first(root):
+          for path_from, matching_node in tree_tools.traverse_serializable(root):
             if not path_from in refs_inserted_to:
               if path_from!=path_to and matching_node is node:
                   ref = tree_tools.Ref(path=path_to)

--- a/xnmt/serialize/tree_tools.py
+++ b/xnmt/serialize/tree_tools.py
@@ -175,7 +175,8 @@ def get_child_dict(node, name):
   return node[name]
 @get_child.register(Serializable)
 def get_child_serializable(node, name):
-  if not hasattr(node, name): raise PathError(f"{node} has not child named {name}")
+  if not hasattr(node, name):
+    raise PathError(f"{node} has not child named {name}")
   return getattr(node,name)
 
 @singledispatch

--- a/xnmt/serialize/tree_tools.py
+++ b/xnmt/serialize/tree_tools.py
@@ -230,10 +230,10 @@ def traverse_serializable(root, path_to_node=Path()):
   yield path_to_node, root
   for child_name, child in name_serializable_children(root):
     yield from traverse_serializable(child, path_to_node.append(child_name))
-
+ 
 def traverse_serializable_breadth_first(root):
   all_nodes = [(path,node) for (path,node) in traverse_serializable(root)]
-  all_nodes.sort(key=lambda x: len(x[0]))
+  all_nodes = [item[1] for item in sorted(enumerate(all_nodes), key=lambda x: (len(x[1][0]),x[0]))]
   return iter(all_nodes)
 
 def traverse_tree_deep(root, cur_node, traversal_order=TraversalOrder.ROOT_FIRST, path_to_node=Path(), named_paths={}):

--- a/xnmt/translator.py
+++ b/xnmt/translator.py
@@ -164,7 +164,10 @@ class DefaultTranslator(Translator, Serializable, Reportable):
       output_actions, score = self.search_strategy.generate_output(self.decoder, self.attender, self.trg_embedder, dec_state, src_length=len(sents), forced_trg_ids=forced_trg_ids)
       # In case of reporting
       if self.report_path is not None:
-        src_words = [self.reporting_src_vocab[w] for w in sents]
+        if self.reporting_src_vocab:
+          src_words = [self.reporting_src_vocab[w] for w in sents]
+        else:
+          src_words = ['' for w in sents]
         trg_words = [self.trg_vocab[w] for w in output_actions.word_ids]
         # Attentions
         attentions = output_actions.attentions


### PR DESCRIPTION
Previously, the reference resolution when saving a model went breadth-first, which caused the model to be specified inside the evaluators and then referenced elsewhere. This made it difficult to load/overwrite certain parts of the model because references are not followed when overwriting. This PR changes to a more natural resolution order, which is probably still not perfect in all situations, but better than before. In the future, we might try following references when doing load/overwrite, and/or keeping track of the reference hierarchy as specified in the original config file.

Also included is an unrelated quick fix for speech reporting.