### PR TITLE
Add sequence accuracy as an evaluation metric

### DIFF
--- a/xnmt/xnmt_evaluate.py
+++ b/xnmt/xnmt_evaluate.py
@@ -4,7 +4,7 @@ import sys
 import io
 import ast
 
-from xnmt.evaluator import BLEUEvaluator, GLEUEvaluator, WEREvaluator, CEREvaluator, RecallEvaluator, ExternalEvaluator, MeanAvgPrecisionEvaluator
+from xnmt.evaluator import BLEUEvaluator, GLEUEvaluator, WEREvaluator, CEREvaluator, RecallEvaluator, ExternalEvaluator, MeanAvgPrecisionEvaluator, SequenceAccuracyEvaluator
 from xnmt.inference import NO_DECODING_ATTEMPTED
 
 """
@@ -71,6 +71,8 @@ def xnmt_evaluate(ref_file=None, hyp_file=None, evaluator="bleu", desc=None):
       logger.warning("no path given for external evaluation script.")
       return None
     evaluator = ExternalEvaluator(path=path, higher_better=higher_better, desc=desc)
+  elif eval_type == 'accuracy':
+    evaluator = SequenceAccuracyEvaluator(desc=desc)
 
   else:
     raise RuntimeError("Unknown evaluation metric {}".format(eval_type))


### PR DESCRIPTION
I did not see a way to evaluate simple sequence accuracy, i.e., the percentage of hypothesis sequences that exactly match the references.

This may not be too relevant for machine translation, but can be for other sequence-to-sequence tasks, and seems basic enough that it should exist.

If I missed something and this already exists, please let me know.