### PR TITLE
Basic config type checking

### DIFF
--- a/xnmt/attender.py
+++ b/xnmt/attender.py
@@ -112,7 +112,7 @@ class DotAttender(Attender, Serializable):
 
   yaml_tag = '!DotAttender'
 
-  def __init__(self, scale=True):
+  def __init__(self, scale:bool=True):
     self.curr_sent = None
     self.scale = scale
     self.attention_vecs = []

--- a/xnmt/batcher.py
+++ b/xnmt/batcher.py
@@ -225,7 +225,7 @@ class SrcBatcher(SortBatcher, Serializable):
   """
   yaml_tag = "!SrcBatcher"
   def __init__(self, batch_size, src_pad_token=Vocab.ES, trg_pad_token=Vocab.ES,
-               break_ties_randomly=True, pad_src_to_multiple=1):
+               break_ties_randomly:bool=True, pad_src_to_multiple=1):
     super(SrcBatcher, self).__init__(batch_size, sort_key=lambda x: len(x[0]), granularity='sent',
                                      src_pad_token=src_pad_token, trg_pad_token=trg_pad_token,
                                      break_ties_randomly=break_ties_randomly,
@@ -244,7 +244,7 @@ class TrgBatcher(SortBatcher, Serializable):
   """
   yaml_tag = "!TrgBatcher"
   def __init__(self, batch_size, src_pad_token=Vocab.ES, trg_pad_token=Vocab.ES,
-               break_ties_randomly=True, pad_src_to_multiple=1):
+               break_ties_randomly:bool=True, pad_src_to_multiple=1):
     super(TrgBatcher, self).__init__(batch_size, sort_key=lambda x: len(x[1]), granularity='sent',
                                      src_pad_token=src_pad_token, trg_pad_token=trg_pad_token,
                                      break_ties_randomly=break_ties_randomly,
@@ -263,7 +263,7 @@ class SrcTrgBatcher(SortBatcher, Serializable):
   """
   yaml_tag = "!SrcTrgBatcher"
   def __init__(self, batch_size, src_pad_token=Vocab.ES, trg_pad_token=Vocab.ES,
-               break_ties_randomly=True, pad_src_to_multiple=1):
+               break_ties_randomly:bool=True, pad_src_to_multiple=1):
     super(SrcTrgBatcher, self).__init__(batch_size, sort_key=lambda x: len(x[0])+1.0e-6*len(x[1]),
                                         granularity='sent',
                                         src_pad_token=src_pad_token, trg_pad_token=trg_pad_token,
@@ -283,7 +283,7 @@ class TrgSrcBatcher(SortBatcher, Serializable):
   """
   yaml_tag = "!TrgSrcBatcher"
   def __init__(self, batch_size, src_pad_token=Vocab.ES, trg_pad_token=Vocab.ES,
-               break_ties_randomly=True, pad_src_to_multiple=1):
+               break_ties_randomly:bool=True, pad_src_to_multiple=1):
     super(TrgSrcBatcher, self).__init__(batch_size, sort_key=lambda x: len(x[1])+1.0e-6*len(x[0]),
                                         granularity='sent',
                                         src_pad_token=src_pad_token, trg_pad_token=trg_pad_token,
@@ -359,7 +359,7 @@ class WordSrcBatcher(WordSortBatcher, Serializable):
   yaml_tag = "!WordSrcBatcher"
 
   def __init__(self, words_per_batch=None, avg_batch_size=None,
-               src_pad_token=Vocab.ES, trg_pad_token=Vocab.ES, break_ties_randomly=True,
+               src_pad_token=Vocab.ES, trg_pad_token=Vocab.ES, break_ties_randomly:bool=True,
                pad_src_to_multiple=1):
     super(WordSrcBatcher, self).__init__(words_per_batch, avg_batch_size, sort_key=lambda x: len(x[0]),
                                          src_pad_token=src_pad_token, trg_pad_token=trg_pad_token,
@@ -386,7 +386,7 @@ class WordTrgBatcher(WordSortBatcher, Serializable):
   yaml_tag = "!WordTrgBatcher"
 
   def __init__(self, words_per_batch=None, avg_batch_size=None,
-               src_pad_token=Vocab.ES, trg_pad_token=Vocab.ES, break_ties_randomly=True,
+               src_pad_token=Vocab.ES, trg_pad_token=Vocab.ES, break_ties_randomly:bool=True,
                pad_src_to_multiple=1):
     super(WordTrgBatcher, self).__init__(words_per_batch, avg_batch_size, sort_key=lambda x: len(x[1]),
                                          src_pad_token=src_pad_token, trg_pad_token=trg_pad_token,
@@ -413,7 +413,7 @@ class WordSrcTrgBatcher(WordSortBatcher, Serializable):
   yaml_tag = "!WordSrcTrgBatcher"
 
   def __init__(self, words_per_batch=None, avg_batch_size=None,
-               src_pad_token=Vocab.ES, trg_pad_token=Vocab.ES, break_ties_randomly=True,
+               src_pad_token=Vocab.ES, trg_pad_token=Vocab.ES, break_ties_randomly:bool=True,
                pad_src_to_multiple=1):
     super(WordSrcTrgBatcher, self).__init__(words_per_batch, avg_batch_size, sort_key=lambda x: len(x[0])+1.0e-6*len(x[1]),
                                             src_pad_token=src_pad_token, trg_pad_token=trg_pad_token,
@@ -440,7 +440,7 @@ class WordTrgSrcBatcher(WordSortBatcher, Serializable):
   yaml_tag = "!WordTrgSrcBatcher"
 
   def __init__(self, words_per_batch=None, avg_batch_size=None,
-               src_pad_token=Vocab.ES, trg_pad_token=Vocab.ES, break_ties_randomly=True,
+               src_pad_token=Vocab.ES, trg_pad_token=Vocab.ES, break_ties_randomly:bool=True,
                pad_src_to_multiple=1):
     return super(WordTrgSrcBatcher, self).__init__(words_per_batch, avg_batch_size, sort_key=lambda x: len(x[1])+1.0e-6*len(x[0]),
                                             src_pad_token=src_pad_token, trg_pad_token=trg_pad_token,

--- a/xnmt/eval_task.py
+++ b/xnmt/eval_task.py
@@ -9,7 +9,6 @@ from xnmt.evaluator import LossScore
 from xnmt.serialize.tree_tools import Path, Ref
 from xnmt.loss import LossBuilder, LossScalarBuilder
 import xnmt.xnmt_evaluate
-from xnmt.experiment import Experiment
 
 class EvalTask(object):
   '''

--- a/xnmt/exp_global.py
+++ b/xnmt/exp_global.py
@@ -6,20 +6,20 @@ from simple_settings import settings
 import dynet as dy
 
 from xnmt.serialize.serializable import Serializable, bare
-from xnmt.param_init import ZeroInitializer, GlorotInitializer
+from xnmt.param_init import ZeroInitializer, GlorotInitializer, ParamInitializer
 
 class ExpGlobal(Serializable):
   """
   An object that holds global settings that can be used by components wherever appropriate. Also holds the DyNet parameter collection.
   
   Args:
-    model_file (str): Location to write model file to
-    log_file (str): Location to write log file to
-    dropout (float): Default dropout probability that should be used by supporting components but can be overwritten
-    weight_noise (float): Default weight noise level that should be used by supporting components but can be overwritten
-    default_layer_dim (int): Default layer dimension that should be used by supporting components but can be overwritten
-    param_init (ParamInitializer): Default parameter initializer that should be used by supporting components but can be overwritten
-    bias_init (ParamInitializer): Default initializer for bias parameters that should be used by supporting components but can be overwritten
+    model_file: Location to write model file to
+    log_file: Location to write log file to
+    dropout: Default dropout probability that should be used by supporting components but can be overwritten
+    weight_noise: Default weight noise level that should be used by supporting components but can be overwritten
+    default_layer_dim: Default layer dimension that should be used by supporting components but can be overwritten
+    param_init: Default parameter initializer that should be used by supporting components but can be overwritten
+    bias_init: Default initializer for bias parameters that should be used by supporting components but can be overwritten
     save_num_checkpoints (int): save DyNet parameters for the most recent n checkpoints, useful for model averaging/ensembling
     eval_only (bool): If True, skip the training loop
     commandline_args: Holds commandline arguments with which XNMT was launched
@@ -27,15 +27,15 @@ class ExpGlobal(Serializable):
   """
   yaml_tag = '!ExpGlobal'
   def __init__(self,
-               model_file=settings.DEFAULT_MOD_PATH,
-               log_file=settings.DEFAULT_LOG_PATH,
-               dropout = 0.3,
-               weight_noise = 0.0,
-               default_layer_dim = 512,
-               param_init=bare(GlorotInitializer),
-               bias_init=bare(ZeroInitializer),
-               save_num_checkpoints=1,
-               eval_only=False,
+               model_file:str=settings.DEFAULT_MOD_PATH,
+               log_file:str=settings.DEFAULT_LOG_PATH,
+               dropout:float = 0.3,
+               weight_noise:float = 0.0,
+               default_layer_dim:int = 512,
+               param_init:ParamInitializer=bare(GlorotInitializer),
+               bias_init:ParamInitializer=bare(ZeroInitializer),
+               save_num_checkpoints:int=1,
+               eval_only:bool=False,
                commandline_args=None,
                dynet_param_collection = None):
     self.model_file = model_file

--- a/xnmt/exp_global.py
+++ b/xnmt/exp_global.py
@@ -35,8 +35,8 @@ class ExpGlobal(Serializable):
                param_init:ParamInitializer=bare(GlorotInitializer),
                bias_init:ParamInitializer=bare(ZeroInitializer),
                save_num_checkpoints:int=1,
-               eval_only:bool=False,
-               commandline_args=None,
+               eval_only:bool = False,
+               commandline_args = None,
                dynet_param_collection = None):
     self.model_file = model_file
     self.log_file = log_file

--- a/xnmt/experiment.py
+++ b/xnmt/experiment.py
@@ -1,28 +1,40 @@
 import logging
 logger = logging.getLogger('xnmt')
+from typing import List
 
 from xnmt.exp_global import ExpGlobal
+from xnmt.preproc_runner import PreprocRunner
 from xnmt.serialize.serializable import Serializable, bare
+from xnmt.training_regimen import TrainingRegimen
+from xnmt.generator import GeneratorModel
+from xnmt.eval_task import EvalTask
 
 class Experiment(Serializable):
   '''
   A default experiment that performs preprocessing, training, and evaluation.
   
   Args:
-    exp_global (ExpGlobal): global experiment settings
-    load (str): path to load a serialized experiment from (if given, only overwrite but no other arguments can be specified)
-    overwrite (list): to be combined with ``load``. list of dictionaries for overwriting individual parts, with dictionaries looking like e.g. ``{"path": exp_global.eval_only, "val": True}``
-    preproc (PreprocRunner): carry out preprocessing if specified
-    model (GeneratorModel): The main model. In the case of multitask training, several models must be specified, in which case the models will live not here but inside the training task objects.
-    train (TrainingRegimen): The training regimen defines the training loop.
-    evaluate (List[EvalTask]): list of tasks to evaluate the model after training finishes.
-    random_search_report (dict): When random search is used, this holds the settings that were randomly drawn for documentary purposes.
+    exp_global: global experiment settings
+    load: to be combined with ``overwrite``. Path to load a serialized experiment from (if given, only overwrite but no other arguments can be specified)
+    overwrite: to be combined with ``load``. List of dictionaries for overwriting individual parts, with dictionaries looking like e.g. ``{"path": exp_global.eval_only, "val": True}``
+    preproc: carry out preprocessing if specified
+    model: The main model. In the case of multitask training, several models must be specified, in which case the models will live not here but inside the training task objects.
+    train: The training regimen defines the training loop.
+    evaluate: list of tasks to evaluate the model after training finishes.
+    random_search_report: When random search is used, this holds the settings that were randomly drawn for documentary purposes.
   '''
 
   yaml_tag = '!Experiment'
 
-  def __init__(self, exp_global=bare(ExpGlobal), load=None, overwrite=None, preproc=None,
-               model=None, train=None, evaluate=None, random_search_report=None):
+  def __init__(self,
+               exp_global:ExpGlobal = bare(ExpGlobal),
+               load:str = None,
+               overwrite:str = None,
+               preproc:PreprocRunner = None,
+               model:GeneratorModel = None,
+               train:TrainingRegimen = None,
+               evaluate:List[EvalTask] = None,
+               random_search_report:dict = None) -> None:
     """
     This is called after all other components have been initialized, so we can safely load DyNet weights here. 
     """

--- a/xnmt/experiment.py
+++ b/xnmt/experiment.py
@@ -1,6 +1,6 @@
 import logging
 logger = logging.getLogger('xnmt')
-from typing import List
+from typing import List, Optional
 
 from xnmt.exp_global import ExpGlobal
 from xnmt.preproc_runner import PreprocRunner
@@ -27,14 +27,14 @@ class Experiment(Serializable):
   yaml_tag = '!Experiment'
 
   def __init__(self,
-               exp_global:ExpGlobal = bare(ExpGlobal),
-               load:str = None,
-               overwrite:str = None,
+               exp_global = bare(ExpGlobal),
+               load:Optional[str] = None,
+               overwrite:Optional[str] = None,
                preproc:PreprocRunner = None,
-               model:GeneratorModel = None,
+               model:Optional[GeneratorModel] = None,
                train:TrainingRegimen = None,
-               evaluate:List[EvalTask] = None,
-               random_search_report:dict = None) -> None:
+               evaluate:Optional[List[EvalTask]] = None,
+               random_search_report:Optional[dict] = None) -> None:
     """
     This is called after all other components have been initialized, so we can safely load DyNet weights here. 
     """

--- a/xnmt/param_init.py
+++ b/xnmt/param_init.py
@@ -94,12 +94,12 @@ class GlorotInitializer(ParamInitializer, Serializable):
   yaml_tag = "!GlorotInitializer"
   def __init__(self, gain=1.0):
     self.gain = gain
-  def initializer(self, dim, is_lookup=False, num_shared=1):
+  def initializer(self, dim:tuple, is_lookup:bool=False, num_shared:int=1):
     """
     Args:
-      dim (tuple): dimensions of parameter tensor
-      is_lookup (bool): Whether the parameter is a lookup parameter
-      num_shared (int): If > 1, treat the first dimension as spanning multiple matrices, each of which is initialized individually
+      dim: dimensions of parameter tensor
+      is_lookup : Whether the parameter is a lookup parameter
+      num_shared: If > 1, treat the first dimension as spanning multiple matrices, each of which is initialized individually
     Returns:
       a dynet initializer object
     """

--- a/xnmt/preproc_runner.py
+++ b/xnmt/preproc_runner.py
@@ -19,16 +19,16 @@ class PreprocRunner(Serializable):
   Preprocess and filter the input files, and create the vocabulary.
 
   Args:
-    preproc_specs (list): A specification for a preprocessing step, including in_files (the input files), out_files (the output files), type (normalize/filter/vocab), and spec for that particular preprocessing type
-                          The types of arguments that preproc_spec expects:
-                          * Option("in_files", help_str="list of paths to the input files"),
-                          * Option("out_files", help_str="list of paths for the output files"),
-                          * Option("type", help_str="type of preprocessing (normalize,filter,vocab)"),
-                          * Option("spec", help_str="The specifications describing which type of processing to use. For normalize and vocab, should consist of the 'lang' and 'spec', where 'lang' can either be 'all' to apply the same type of processing to all languages, or a zero-indexed integer indicating which language to process."),
-    overwrite (bool): Whether to overwrite files if they already exist.
+    preproc_specs: A specification for a preprocessing step, including in_files (the input files), out_files (the output files), type (normalize/filter/vocab), and spec for that particular preprocessing type
+                    The types of arguments that preproc_spec expects:
+                    * Option("in_files", help_str="list of paths to the input files"),
+                    * Option("out_files", help_str="list of paths for the output files"),
+                    * Option("type", help_str="type of preprocessing (normalize,filter,vocab)"),
+                    * Option("spec", help_str="The specifications describing which type of processing to use. For normalize and vocab, should consist of the 'lang' and 'spec', where 'lang' can either be 'all' to apply the same type of processing to all languages, or a zero-indexed integer indicating which language to process."),
+    overwrite: Whether to overwrite files if they already exist.
   """
   yaml_tag = "!PreprocRunner"
-  def __init__(self, preproc_specs, overwrite=False):
+  def __init__(self, preproc_specs:list, overwrite:bool=False):
     logger.info("> Preprocessing")
     
     args = dict(preproc_specs=preproc_specs, overwrite=overwrite)

--- a/xnmt/serialize/serializer.py
+++ b/xnmt/serialize/serializer.py
@@ -161,6 +161,18 @@ class YamlSerializer(object):
           tree_tools.set_descendant(root, path, initialized_component)
     return root
 
+  def check_init_param_types(self, obj, init_params):
+    for init_param_name in init_params:
+      param_sig = tree_tools.get_init_args_defaults(obj)
+      if init_param_name in param_sig:
+        annotated_type = param_sig[init_param_name].annotation
+        if annotated_type != inspect.Parameter.empty:
+          try:
+            if not isinstance(init_params[init_param_name], annotated_type):
+              raise ValueError(f"type check failed for {init_param_name} argument of {obj}: expected {annotated_type}, received {init_params[init_param_name]} of type {type(init_params[init_param_name])}")
+          except TypeError:
+            pass # isinstance does not work with types from Python's "typing" module, let's skip test
+
   @lru_cache(maxsize=None)
   def init_component(self, path):
     """
@@ -176,6 +188,7 @@ class YamlSerializer(object):
     serialize_params = OrderedDict(init_params)
     init_args = tree_tools.get_init_args_defaults(obj)
     if "yaml_path" in init_args: init_params["yaml_path"] = path
+    self.check_init_param_types(obj, init_params)
     try:
       initialized_obj = obj.__class__(**init_params)
       logger.debug(f"initialized {path}: {obj.__class__.__name__}@{id(obj)}({dict(init_params)})"[:1000])

--- a/xnmt/training_regimen.py
+++ b/xnmt/training_regimen.py
@@ -68,7 +68,7 @@ class SimpleTrainingRegimen(SimpleTrainingTask, TrainingRegimen, Serializable):
                dev_every=0, batcher=bare(xnmt.batcher.SrcBatcher, batch_size=32),
                loss_calculator=None, trainer=None, run_for_epochs=None,
                lr_decay=1.0, lr_decay_times=3, patience=1, initial_patience=None,
-               dev_tasks=None, restart_trainer=False, reload_command=None,
+               dev_tasks=None, restart_trainer:bool=False, reload_command=None,
                name=None, sample_train_sents=None, max_num_train_sents=None,
                max_src_len=None, max_trg_len=None,
                exp_global=Ref(Path("exp_global"))):


### PR DESCRIPTION
This is a suggestion to perform basic type checking of values specified in YAML configs. This will catch some common errors such as ```overwrite: Fals``` being interpreted as equal to ```True``` (the spelling mistake makes this a string rather than bool).

It uses Python type annotations, so I moved some of the type documentation from the docstring to the method definition. Either is fine according to the Google documentation guidelines, although it might be a bit confusing for people not familiar with this, so let me know if you have reservations.

As a limitation, this currently only checks "normal" types (like ```bool``` or ```Experiment```), not things from the typing module (like ```List[int]``` or ```Optional[Experiment]```), which means it can currently only catch some of the simpler cases but could be extended later if necessary.
