### PR TITLE
Refactor scoring

### DIFF
--- a/xnmt/eval_task.py
+++ b/xnmt/eval_task.py
@@ -106,7 +106,7 @@ class AccuracyEvalTask(Serializable):
                desc: Optional = None):
     self.model = model
     if isinstance(eval_metrics, str):
-      eval_metrics = [xnmt.xnmt_evaluate.eval_shortcuts[shortcut] for shortcut in eval_metrics.split(",")]
+      eval_metrics = [xnmt.xnmt_evaluate.eval_shortcuts[shortcut]() for shortcut in eval_metrics.split(",")]
     self.eval_metrics = eval_metrics
     self.src_file = src_file
     self.ref_file = ref_file

--- a/xnmt/eval_task.py
+++ b/xnmt/eval_task.py
@@ -1,13 +1,19 @@
+from typing import Sequence, Union, Any, Optional
+
 from simple_settings import settings
 
 import dynet as dy
 
+from xnmt.evaluator import Evaluator
+from xnmt.generator import GeneratorModel
+from xnmt.inference import SimpleInference
 import xnmt.input_reader
-from xnmt.serialize.serializable import Serializable, Path, Ref
+from xnmt.serialize.serializable import Serializable, Ref
 from xnmt.serialize.serializer import serializable_init
 from xnmt.loss_calculator import LossCalculator, MLELoss
 from xnmt.evaluator import LossScore
 from xnmt.loss import LossBuilder, LossScalarBuilder
+from xnmt.util import OneOrSeveral
 import xnmt.xnmt_evaluate
 
 class EvalTask(object):
@@ -81,24 +87,27 @@ class AccuracyEvalTask(Serializable):
   A task that does evaluation of some measure of accuracy.
 
   Args:
-    src_file (str):
-    ref_file (str):
-    hyp_file (str):
-    model (GeneratorModel):
-    eval_metrics (str): comma-separated list of evaluation metrics
-    inference (SimpleInference):
+    src_file: path(s) to read source file from
+    ref_file: path(s) to read reference file from
+    hyp_file: path to write hypothesis file to
+    model: generator model to generate hypothesis with
+    eval_metrics: list of evaluation metrics (list of Evaluator objects or string of comma-separated shortcuts)
+    inference: inference object
     candidate_id_file (str):
-    desc (str):
+    desc: human-readable description passed on to resulting score objects
   '''
 
   yaml_tag = '!AccuracyEvalTask'
 
   @serializable_init
-  def __init__(self, src_file, ref_file, hyp_file, model=Ref("model"),
-               eval_metrics="bleu", inference=None, candidate_id_file=None,
-               desc=None):
+  def __init__(self, src_file: OneOrSeveral[str], ref_file: OneOrSeveral[str], hyp_file: str,
+               model: GeneratorModel = Ref("model"), eval_metrics: Union[str, Sequence[Evaluator]] = "bleu",
+               inference: Optional[SimpleInference] = None, candidate_id_file: Optional[str] = None,
+               desc: Optional = None):
     self.model = model
-    self.eval_metrics = [s.lower() for s in eval_metrics.split(",")]
+    if isinstance(eval_metrics, str):
+      eval_metrics = [xnmt.xnmt_evaluate.eval_shortcuts[shortcut] for shortcut in eval_metrics.split(",")]
+    self.eval_metrics = eval_metrics
     self.src_file = src_file
     self.ref_file = ref_file
     self.hyp_file = hyp_file
@@ -113,15 +122,11 @@ class AccuracyEvalTask(Serializable):
                    candidate_id_file = self.candidate_id_file)
     # TODO: This is not ideal because it requires reading the data
     #       several times. Is there a better way?
-    evaluate_args = {}
-    evaluate_args["hyp_file"] = self.hyp_file
-    evaluate_args["ref_file"] = self.ref_file
-    evaluate_args["desc"] = self.desc
+
     # Evaluate
-    eval_scores = []
-    for eval_metric in self.eval_metrics:
-      evaluate_args["evaluator"] = eval_metric
-      eval_scores.append(xnmt.xnmt_evaluate.xnmt_evaluate(**evaluate_args))
+    eval_scores = xnmt.xnmt_evaluate.xnmt_evaluate(hyp_file=self.hyp_file, ref_file=self.ref_file, desc=self.desc,
+                                                   evaluators=self.eval_metrics)
+
     # Calculate the reference file size
     ref_words_cnt = 0
     for ref_sent in self.model.trg_reader.read_sents(self.ref_file):

--- a/xnmt/evaluator.py
+++ b/xnmt/evaluator.py
@@ -7,6 +7,7 @@ import subprocess
 import numpy as np
 
 from xnmt.serialize.serializable import Serializable
+from xnmt.serialize.serializer import serializable_init
 
 class EvalScore(object):
   def higher_is_better(self):
@@ -188,9 +189,12 @@ class Evaluator(object):
   def evaluate_fast(self, ref, hyp):
     raise NotImplementedError('evaluate_fast is not implemented for:', self.__class__.__name__)
 
-class BLEUEvaluator(Evaluator):
+class BLEUEvaluator(Evaluator, Serializable):
   # Class for computing BLEU Scores accroding to
   # K Papineni et al "BLEU: a method for automatic evaluation of machine translation"
+  yaml_tag = "!BLEUEvaluator"
+
+  @serializable_init
   def __init__(self, ngram=4, smooth=0):
     """
     Args:
@@ -342,8 +346,10 @@ class BLEUEvaluator(Evaluator):
 
     return clipped_ngram_count, candidate_ngram_count
 
-class GLEUEvaluator(Evaluator):
+class GLEUEvaluator(Evaluator, Serializable):
   # Class for computing GLEU Scores
+  yaml_tag = "!GLEUEvaluator"
+  @serializable_init
   def __init__(self, min_length=1, max_length=4):
     self.min = min_length
     self.max = max_length
@@ -404,11 +410,12 @@ class GLEUEvaluator(Evaluator):
     return GLEUScore(gleu_score, total_ref_len, total_hyp_len, desc=desc)
 
 
-class WEREvaluator(Evaluator):
+class WEREvaluator(Evaluator, Serializable):
   """
   A class to evaluate the quality of output in terms of word error rate.
   """
-
+  yaml_tag = "!WEREvaluator"
+  @serializable_init
   def __init__(self, case_sensitive=False):
     self.case_sensitive = case_sensitive
 
@@ -479,11 +486,13 @@ class WEREvaluator(Evaluator):
         F[i + 1][j + 1] = max(match, delete, insert)
     return F[len(l1)][len(l2)]
 
-class CEREvaluator(object):
+class CEREvaluator(Evaluator, Serializable):
   """
   A class to evaluate the quality of output in terms of character error rate.
   """
+  yaml_tag = "!CEREvaluator"
 
+  @serializable_init
   def __init__(self, case_sensitive=False):
     self.wer_evaluator = WEREvaluator(case_sensitive=case_sensitive)
 
@@ -505,12 +514,13 @@ class CEREvaluator(object):
     wer_obj = self.wer_evaluator.evaluate(ref_char, hyp_char)
     return CERScore(wer_obj.value(), wer_obj.hyp_len, wer_obj.ref_len, desc=desc)
 
-class ExternalEvaluator(object):
+class ExternalEvaluator(Evaluator, Serializable):
   """
   A class to evaluate the quality of the output according to an external evaluation script.
   The external script should only print a number representing the calculated score.
   """
-
+  yaml_tag = "!ExternalEvaluator"
+  @serializable_init
   def __init__(self, path=None, higher_better=True):
     self.path = path
     self.higher_better = higher_better
@@ -533,7 +543,9 @@ class ExternalEvaluator(object):
     external_score = float(out)
     return ExternalScore(external_score, self.higher_better, desc=desc)
 
-class RecallEvaluator(object):
+class RecallEvaluator(Evaluator,Serializable):
+  yaml_tag = "!RecallEvaluator"
+  @serializable_init
   def __init__(self, nbest=5):
     self.nbest = nbest
 
@@ -548,11 +560,12 @@ class RecallEvaluator(object):
     score = true_positive / float(len(ref))
     return RecallScore(score, len(hyp), len(ref), nbest=self.nbest, desc=desc)
 
-class SequenceAccuracyEvaluator(Evaluator):
+class SequenceAccuracyEvaluator(Evaluator, Serializable):
   """
   A class to evaluate the quality of output in terms of sequence accuracy.
   """
-
+  yaml_tag = "!SequenceAccuracyEvaluator"
+  @serializable_init
   def __init__(self, case_sensitive=False):
     self.case_sensitive = case_sensitive
 

--- a/xnmt/evaluator.py
+++ b/xnmt/evaluator.py
@@ -560,6 +560,29 @@ class RecallEvaluator(Evaluator,Serializable):
     score = true_positive / float(len(ref))
     return RecallScore(score, len(hyp), len(ref), nbest=self.nbest, desc=desc)
 
+# The below is needed for evaluating retrieval models, but depends on MeanAvgPrecisionScore which seems to have been
+# lost.
+#
+# class MeanAvgPrecisionEvaluator(object):
+#   def __init__(self, nbest=5, desc=None):
+#     self.nbest = nbest
+#     self.desc = desc
+#
+#   def metric_name(self):
+#     return "MeanAvgPrecision{}".format(str(self.nbest))
+#
+#   def evaluate(self, ref, hyp):
+#     avg = 0
+#     for hyp_i, ref_i in zip(hyp, ref):
+#         score = 0
+#         h = hyp_i[:self.nbest]
+#         for x in range(len(h)):
+#             if ref_i == h[x][0]:
+#                 score = 1/(x+1)
+#         avg += score
+#     avg = avg/float(len(ref))
+#     return MeanAvgPrecisionScore(avg, len(hyp), len(ref), nbest=self.nbest, desc=self.desc)
+
 class SequenceAccuracyEvaluator(Evaluator, Serializable):
   """
   A class to evaluate the quality of output in terms of sequence accuracy.

--- a/xnmt/inference.py
+++ b/xnmt/inference.py
@@ -12,8 +12,9 @@ import dynet as dy
 from xnmt.loss_calculator import LossCalculator
 import xnmt.output
 from xnmt.reports import Reportable
-from xnmt.serialize.serializable import Serializable, Ref, Path
+from xnmt.serialize.serializable import Serializable, Ref
 from xnmt.serialize.serializer import serializable_init
+from xnmt.util import make_parent_dir
 
 NO_DECODING_ATTEMPTED = "@@NO_DECODING_ATTEMPTED@@"
 
@@ -132,9 +133,7 @@ class SimpleInference(Serializable):
       ref_scores = [-x for x in ref_scores]
 
     # Make the parent directory if necessary
-    directory = os.path.dirname(args["trg_file"])
-    if not os.path.exists(directory):
-      os.makedirs(directory)
+    make_parent_dir(args["trg_file"])
 
     # Perform generation of output
     if args["mode"] != 'score':

--- a/xnmt/preproc.py
+++ b/xnmt/preproc.py
@@ -17,6 +17,7 @@ import yaml
 from xnmt.serialize.serializable import Serializable
 from xnmt.serialize.serializer import serializable_init
 from xnmt.speech_features import logfbank, calculate_delta, get_mean_std, normalize
+from xnmt.util import make_parent_dir
 
 ##### Preprocessors
 
@@ -194,12 +195,7 @@ class SentencepieceTokenizer(ExternalTokenizer):
     self.encode_extra_options = ['--extra_options='+encode_extra_options] if encode_extra_options else []
     self.decode_extra_options = ['--extra_options='+decode_extra_options] if decode_extra_options else []
 
-    if not os.path.exists(os.path.dirname(model_prefix)):
-      try:
-        os.makedirs(os.path.dirname(model_prefix))
-      except OSError as exc:
-        if exc.errno != os.errno.EEXIST:
-          raise
+    make_parent_dir(model_prefix)
 
     if ((not os.path.exists(self.model_prefix + '.model')) or
         (not os.path.exists(self.model_prefix + '.vocab')) or

--- a/xnmt/preproc_runner.py
+++ b/xnmt/preproc_runner.py
@@ -6,14 +6,7 @@ from typing import List
 from xnmt.preproc import Normalizer, SentenceFilterer, VocabFilterer
 from xnmt.serialize.serializable import Serializable
 from xnmt.serialize.serializer import serializable_init
-
-def make_parent_dir(filename):
-  if not os.path.exists(os.path.dirname(filename)):
-    try:
-      os.makedirs(os.path.dirname(filename))
-    except OSError as exc: # Guard against race condition
-      if exc.errno != os.errno.EEXIST:
-        raise
+from xnmt.util import make_parent_dir
 
 class PreprocTask(object):
   def run_preproc_task(self, overwrite=False):

--- a/xnmt/serialize/serializer.py
+++ b/xnmt/serialize/serializer.py
@@ -307,7 +307,7 @@ def serializable_init(f):
         assert not getattr(initialized, "_is_bare", False)
         serialize_params[key] = initialized
     f(obj, **serialize_params)
-    if xnmt_subcol_name in ParamManager.param_col.subcols:
+    if ParamManager.initialized and xnmt_subcol_name in ParamManager.param_col.subcols:
       serialize_params["xnmt_subcol_name"] = xnmt_subcol_name
     serialize_params.update(getattr(obj,"serialize_params",{}))
     obj.serialize_params = serialize_params

--- a/xnmt/serialize/serializer.py
+++ b/xnmt/serialize/serializer.py
@@ -185,7 +185,7 @@ class YamlSerializer(object):
         if annotated_type != inspect.Parameter.empty:
           try:
             if not isinstance(init_params[init_param_name], annotated_type):
-              raise ValueError(f"type check failed for {init_param_name} argument of {obj}: expected {annotated_type}, received {init_params[init_param_name]} of type {type(init_params[init_param_name])}")
+              raise ValueError(f"type check failed for '{init_param_name}' argument of {obj}: expected {annotated_type}, received {init_params[init_param_name]} of type {type(init_params[init_param_name])}")
           except TypeError:
             pass # isinstance does not work with types from Python's "typing" module, let's skip test
 

--- a/xnmt/tee.py
+++ b/xnmt/tee.py
@@ -4,6 +4,8 @@ import logging
 from simple_settings import settings
 import yaml
 
+from xnmt.util import make_parent_dir
+
 STD_OUTPUT_LEVELNO = 35
 
 class NoErrorFilter(logging.Filter):
@@ -52,9 +54,7 @@ yaml_logger.setLevel(logging.INFO)
 
 def set_out_file(out_file):
   unset_out_file()
-  dirname = os.path.dirname(out_file)
-  if dirname and not os.path.exists(dirname):
-    os.makedirs(dirname)  
+  make_parent_dir(out_file)
   fh = logging.FileHandler(out_file, mode='w')
   fh.setLevel(settings.LOG_LEVEL_FILE)
   fh.setFormatter(MainFormatter())

--- a/xnmt/util.py
+++ b/xnmt/util.py
@@ -1,0 +1,13 @@
+import os
+from typing import TypeVar, Sequence, Union
+T = TypeVar('T')
+
+OneOrSeveral = Union[T,Sequence[T]]
+
+def make_parent_dir(filename):
+  if not os.path.exists(os.path.dirname(filename)):
+    try:
+      os.makedirs(os.path.dirname(filename))
+    except OSError as exc: # Guard against race condition
+      if exc.errno != os.errno.EEXIST:
+        raise

--- a/xnmt/xnmt_evaluate.py
+++ b/xnmt/xnmt_evaluate.py
@@ -1,15 +1,11 @@
 import logging
 logger = logging.getLogger('xnmt')
-import sys
-import ast
+from typing import Any, Sequence
+import argparse
 
-from xnmt.evaluator import BLEUEvaluator, GLEUEvaluator, WEREvaluator, CEREvaluator, RecallEvaluator, ExternalEvaluator, MeanAvgPrecisionEvaluator, SequenceAccuracyEvaluator
+from xnmt.evaluator import *
 from xnmt.inference import NO_DECODING_ATTEMPTED
-
-"""
-Command line usage:
-  python xnmt_evaluate.py <ref> <hyp> <metric>
-"""
+from xnmt.util import OneOrSeveral
 
 def read_data(loc_, post_process=None):
   """Reads the lines in the file specified in loc_ and return the list after inserting the tokens
@@ -23,75 +19,57 @@ def read_data(loc_, post_process=None):
       data.append(t)
   return data
 
-def eval_or_empty_list(x):
-  try:
-    return ast.literal_eval(x)
-  except:
-    return []
+eval_shortcuts = {
+  "bleu": BLEUEvaluator(),
+  "gleu": GLEUEvaluator(),
+  "wer": WEREvaluator(),
+  "cer": CEREvaluator(),
+  "recall": RecallEvaluator(),
+  "accuracy": SequenceAccuracyEvaluator()
+}
 
-def xnmt_evaluate(ref_file=None, hyp_file=None, evaluator="bleu", desc=None):
+
+def xnmt_evaluate(ref_file: OneOrSeveral[str], hyp_file: OneOrSeveral[str],
+                  evaluators: Sequence[Evaluator] = [BLEUEvaluator()], desc: Any = None) -> Sequence[EvalScore]:
   """"Returns the eval score (e.g. BLEU) of the hyp sents using reference trg sents
 
   Args:
-    ref_file (str): path of the reference file
-    hyp_file (str): path of the hypothesis trg file
-    evaluator (str): Evaluation metrics (bleu/wer/cer)
-    desc (str): descriptive string passed on to evaluators
+    ref_file: path of the reference file
+    hyp_file: path of the hypothesis trg file
+    evaluators: Evaluation metrics. Can be a list of evaluator objects, or a shortcut string
+    desc: descriptive string passed on to evaluators
   """
-  args = dict(ref_file=ref_file, hyp_file=hyp_file, evaluator=evaluator)
-  cols = args["evaluator"].split("|")
-  eval_type  = cols[0]
-  eval_param = {} if len(cols) == 1 else {key: value for key, value in [param.split("=") for param in cols[1].split()]}
-
   hyp_postprocess = lambda line: line.split()
   ref_postprocess = lambda line: line.split()
-  if eval_type == "bleu":
-    ngram = int(eval_param.get("ngram", 4))
-    evaluator = BLEUEvaluator(ngram=int(ngram), desc=desc)
-  elif eval_type == "gleu":
-    min_len = int(eval_param.get("min", 1))
-    max_len = int(eval_param.get("max", 4))
-    evaluator = GLEUEvaluator(min_length=min_len, max_length=max_len, desc=desc)
-  elif eval_type == "wer":
-    evaluator = WEREvaluator(desc=desc)
-  elif eval_type == "cer":
-    evaluator = CEREvaluator(desc=desc)
-  elif eval_type == "recall":
-    nbest = int(eval_param.get("nbest", 5))
-    hyp_postprocess = lambda x: eval_or_empty_list(x)
-    ref_postprocess = lambda x: int(x)
-    evaluator = RecallEvaluator(nbest=int(nbest), desc=desc)
-  elif eval_type == "mean_avg_precision":
-    nbest = int(eval_param.get("nbest", 5))
-    hyp_postprocess = lambda x: ast.literal_eval(x)
-    ref_postprocess = lambda x: int(x)
-    evaluator = MeanAvgPrecisionEvaluator(nbest=int(nbest), desc=desc)
-  elif eval_type == 'external':
-    path = eval_param.get("path", None)
-    higher_better = eval_param.get("higher_better", True)
-    if path == None:
-      logger.warning("no path given for external evaluation script.")
-      return None
-    evaluator = ExternalEvaluator(path=path, higher_better=higher_better, desc=desc)
-  elif eval_type == 'accuracy':
-    evaluator = SequenceAccuracyEvaluator(desc=desc)
 
-  else:
-    raise RuntimeError("Unknown evaluation metric {}".format(eval_type))
-
-  ref_corpus = read_data(args["ref_file"], post_process=ref_postprocess)
-  hyp_corpus = read_data(args["hyp_file"], post_process=hyp_postprocess)
+  ref_corpus = read_data(ref_file, post_process=ref_postprocess)
+  hyp_corpus = read_data(hyp_file, post_process=hyp_postprocess)
   len_before = len(hyp_corpus)
   ref_corpus, hyp_corpus = zip(*filter(lambda x: NO_DECODING_ATTEMPTED not in x[1], zip(ref_corpus, hyp_corpus)))
   if len(ref_corpus) < len_before:
-    logger.info("> ignoring %s out of %s test sentences." % (len_before - len(ref_corpus), len_before))
+    logger.info(f"> ignoring {len_before - len(ref_corpus)} out of {len_before} test sentences.")
 
-  eval_score = evaluator.evaluate(ref_corpus, hyp_corpus)
-  return eval_score
+  return [evaluator.evaluate(ref_corpus, hyp_corpus, desc=desc) for evaluator in evaluators]
 
 if __name__ == "__main__":
+  parser = argparse.ArgumentParser()
+  parser.add_argument("ref", help="Path to read reference file from")
+  parser.add_argument("hyp", help="Path to read hypothesis file from")
+  parser.add_argument("metrics", help=f"Scoring metric(s), a comma-separated string. "
+                                      f"Accepted metrics are {', '.join(eval_shortcuts.keys())}. Alternatively, "
+                                      f"metrics with non-default settings can by used by specifying a Python list of "
+                                      f"Evaluator objects to be parsed using eval(). "
+                                      f"Example: '[WEREvaluator(case_sensitive=True)]'")
+  parser.add_argument("--settings")
+  args = parser.parse_args()
 
-  args = sys.argv[1:]
-  score = xnmt_evaluate(*args)
-  print(f"{args[2]} Score = {score}")
+  evaluators = args.metrics
+  try:
+    evaluators = [eval_shortcuts[shortcut] for shortcut in evaluators.split(",")]
+  except KeyError:
+    evaluators = eval(evaluators)
+
+  scores = xnmt_evaluate(args.ref, args.hyp, evaluators)
+  for score in scores:
+    print(score)
 

--- a/xnmt/xnmt_evaluate.py
+++ b/xnmt/xnmt_evaluate.py
@@ -5,6 +5,7 @@ import argparse
 
 from xnmt.evaluator import *
 from xnmt.inference import NO_DECODING_ATTEMPTED
+from xnmt.serialize.serializable import bare
 from xnmt.util import OneOrSeveral
 
 def read_data(loc_, post_process=None):
@@ -20,17 +21,17 @@ def read_data(loc_, post_process=None):
   return data
 
 eval_shortcuts = {
-  "bleu": BLEUEvaluator(),
-  "gleu": GLEUEvaluator(),
-  "wer": WEREvaluator(),
-  "cer": CEREvaluator(),
-  "recall": RecallEvaluator(),
-  "accuracy": SequenceAccuracyEvaluator()
+  "bleu": lambda:BLEUEvaluator(),
+  "gleu": lambda:GLEUEvaluator(),
+  "wer": lambda:WEREvaluator(),
+  "cer": lambda:CEREvaluator(),
+  "recall": lambda:RecallEvaluator(),
+  "accuracy": lambda:SequenceAccuracyEvaluator(),
 }
 
 
 def xnmt_evaluate(ref_file: OneOrSeveral[str], hyp_file: OneOrSeveral[str],
-                  evaluators: Sequence[Evaluator] = [BLEUEvaluator()], desc: Any = None) -> Sequence[EvalScore]:
+                  evaluators: Sequence[Evaluator], desc: Any = None) -> Sequence[EvalScore]:
   """"Returns the eval score (e.g. BLEU) of the hyp sents using reference trg sents
 
   Args:
@@ -65,7 +66,7 @@ if __name__ == "__main__":
 
   evaluators = args.metrics
   try:
-    evaluators = [eval_shortcuts[shortcut] for shortcut in evaluators.split(",")]
+    evaluators = [eval_shortcuts[shortcut]() for shortcut in evaluators.split(",")]
   except KeyError:
     evaluators = eval(evaluators)
 


### PR DESCRIPTION
This is partly a code cleanup, partly making evaluation more flexible:
- xnmt_evaluate via command line mode now takes either a string like ```bleu,gleu```as metrics, or a fully configurable list of python object such as ```WEREvaluator(case_sensitive=True),BLEUEvaluator()]```. Previously, the latter was not possible, so evaluators could only be used with default settings. 
- the same holds for the metrics of the ```AccuracyEvalTask```.

I do think the ```bleu,gleu``` string shortcut is a good idea for the command line because we don't want to specify python objects if we don't have to, and the required extra code is quite simple. The main question is whether this is true for YAML configs also: do we want to support ```eval_metrics:wer,bleu``` or only ```eval_metrics: [!WEREvaluator {}, !BLEUEvaluator {}]```? And if we support the former, do we want to use the shortcuts or the more consistent YAML style in the example configs?