### PR TITLE
Length norm improvements

### DIFF
--- a/xnmt/length_normalization.py
+++ b/xnmt/length_normalization.py
@@ -1,3 +1,6 @@
+from numbers import Real
+from typing import Sequence, Optional
+
 import numpy as np
 from scipy.stats import norm
 
@@ -7,13 +10,16 @@ class LengthNormalization(object):
   '''
   A template class to generate translation from the output probability model.
   '''
-  def normalize_completed(self, completed_hyps, src_length=None):
+  def normalize_completed(self, completed_hyps:Sequence['Hypothesis'], src_length:Optional[int]=None) \
+          -> Sequence[float]:
     """
-    Normalization step applied to completed hypotheses after search.
+    Apply normalization step to completed hypotheses after search and return the normalized scores.
     
     Args:
       completed_hyps: list of completed Hypothesis objects, will be normalized in-place
       src_length: length of source sequence (None if not given)
+    Returns:
+      normalized scores
     """
     raise NotImplementedError('normalize_completed must be implemented in LengthNormalization subclasses')
   def normalize_partial(self, score_so_far, score_to_add, new_len):
@@ -38,9 +44,9 @@ class NoNormalization(LengthNormalization, Serializable):
   def __init__(self):
     pass
 
-  def normalize_completed(self, completed_hyps, src_length=None):
-    pass
-
+  def normalize_completed(self, completed_hyps:Sequence['Hypothesis'], src_length:Optional[int]=None) \
+          -> Sequence[float]:
+    return [hyp.score for hyp in completed_hyps]
 
 class AdditiveNormalization(LengthNormalization, Serializable):
   '''
@@ -49,14 +55,16 @@ class AdditiveNormalization(LengthNormalization, Serializable):
   yaml_tag = '!AdditiveNormalization'
 
   @serializable_init
-  def __init__(self, penalty=-0.1, apply_during_search=False):
+  def __init__(self, penalty:Real=-0.1, apply_during_search:bool=False):
     self.penalty = penalty
     self.apply_during_search = apply_during_search
 
-  def normalize_completed(self, completed_hyps, src_length=None):
-    if not self.apply_during_search:
-      for hyp in completed_hyps:
-        hyp.score += (len(hyp.id_list) * self.penalty)
+  def normalize_completed(self, completed_hyps:Sequence['Hypothesis'], src_length:Optional[int]=None) \
+          -> Sequence[float]:
+    if self.apply_during_search:
+      return [hyp.score for hyp in completed_hyps]
+    else:
+      return [hyp.score + (len(hyp.id_list) * self.penalty) for hyp in completed_hyps]
   def normalize_partial(self, score_so_far, score_to_add, new_len):
     return score_so_far + score_to_add + (self.penalty if self.apply_during_search else 0.0)
 
@@ -68,14 +76,16 @@ class PolynomialNormalization(LengthNormalization, Serializable):
   yaml_tag = '!PolynomialNormalization'
 
   @serializable_init
-  def __init__(self, m=1, apply_during_search=False):
+  def __init__(self, m:Real=1, apply_during_search:bool=False):
     self.m = m
     self.apply_during_search = apply_during_search
 
-  def normalize_completed(self, completed_hyps, src_length=None):
-    if not self.apply_during_search:
-      for hyp in completed_hyps:
-        hyp.score /= pow(len(hyp.id_list), self.m)
+  def normalize_completed(self, completed_hyps:Sequence['Hypothesis'], src_length:Optional[int]=None) \
+          -> Sequence[float]:
+    if self.apply_during_search:
+      return [hyp.score for hyp in completed_hyps]
+    else:
+      return [(hyp.score / pow(len(hyp.output.word_ids), self.m)) for hyp in completed_hyps]
   def normalize_partial(self, score_so_far, score_to_add, new_len):
     if self.apply_during_search:
       return (score_so_far * pow(new_len-1, self.m) + score_to_add) / pow(new_len, self.m)
@@ -109,8 +119,8 @@ class MultinomialNormalization(LengthNormalization, Serializable):
       src_length: length of the src sent
     """
     assert (src_length is not None), "Length of Source Sentence is required"
-    for hyp in completed_hyps:
-      hyp.score += np.log(self.trg_length_prob(src_length, len(hyp.id_list)))
+
+    return [hyp.score + np.log(self.trg_length_prob(src_length, len(hyp.id_list))) for hyp in completed_hyps]
 
 
 class GaussianNormalization(LengthNormalization, Serializable):
@@ -141,6 +151,6 @@ class GaussianNormalization(LengthNormalization, Serializable):
   def trg_length_prob(self, trg_length):
     return self.distr.pdf(trg_length)
 
-  def normalize_completed(self, completed_hyps, src_length=None):
-    for hyp in completed_hyps:
-      hyp.score /= self.trg_length_prob(len(hyp.id_list))
+  def normalize_completed(self, completed_hyps:Sequence['Hypothesis'], src_length:Optional[int]=None) \
+          -> Sequence[float]:
+    return [hyp.score / self.trg_length_prob(len(hyp.id_list)) for hyp in completed_hyps]

--- a/xnmt/search_strategy.py
+++ b/xnmt/search_strategy.py
@@ -119,7 +119,8 @@ class BeamSearch(SearchStrategy):
     if len(completed_hyp) == 0:
       completed_hyp = active_hyp
 
-    self.len_norm.normalize_completed(completed_hyp, src_length)
+    normalized_scores = self.len_norm.normalize_completed(completed_hyp, src_length)
+    completed_hyp = [Hypothesis(normalized_scores[i], hyp.output, hyp.state) for i,hyp in enumerate(completed_hyp)]
 
     result = sorted(completed_hyp, key=lambda x: x.score, reverse=True)[0]
     return result.output, result.score


### PR DESCRIPTION
- fix length normalization not working in case of ```apply_during_search=False```
- speed up ```PolynomialNormalization``` by precomputing powers of sequence lengths that are otherwise recomputed a large number of times. Overall speedup of beam search is about 10%.