### PR TITLE
dev_every: remove special handling of new epoch events

### DIFF
--- a/xnmt/loss_tracker.py
+++ b/xnmt/loss_tracker.py
@@ -53,7 +53,6 @@ class LossTracker(object):
       self.epoch_num += 1
       self.sent_num = 0
       self.sent_num_not_report_train = 0
-      self.sent_num_not_report_dev = 0
       self.last_report_words = 0
       self.last_report_train_time = time.time()
 
@@ -126,7 +125,7 @@ class LossTracker(object):
 
   def should_report_dev(self):
     if self.eval_dev_every > 0:
-      return self.sent_num_not_report_dev >= self.eval_dev_every or (self.sent_num == self.total_train_sent)
+      return self.sent_num_not_report_dev >= self.eval_dev_every
     else:
       return self.sent_num_not_report_dev >= self.total_train_sent
 

--- a/xnmt/training_task.py
+++ b/xnmt/training_task.py
@@ -279,6 +279,7 @@ class SimpleTrainingTask(TrainingTask, Serializable):
 
     # Perform evaluation
     if self.dev_tasks and len(self.dev_tasks) > 0:
+      logger.info("> Checkpoint")
       dev_scores = []
       for dev_task in self.dev_tasks:
         dev_score, dev_word_cnt = dev_task.eval()
@@ -293,7 +294,6 @@ class SimpleTrainingTask(TrainingTask, Serializable):
 
     # Control the learning schedule
     if control_learning_schedule:
-      logger.info("> Checkpoint")
       # Write out the model if it's the best one
       if self.logger.report_dev_and_check_model():
         ret = True


### PR DESCRIPTION
Currently, checkpoints are made whenever an epoch is finished, or more often in case ```dev_every``` is set.  It is not possible to have checkpoints less often than at every epoch though, even if setting ```dev_every``` to a value greater than the number of training sentences. This commit changes this behavior: finishing an epoch has no special significance if ```dev_every``` is set, so that we can set it so that checkpoints are less often than once every epoch (useful e.g. in connection with ```sample_train_sents```).