### PR TITLE
Removed unnecessary requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,7 @@ xnmt/cython/*.cpp
 xnmt/cython/*.c
 xnmt/cython/*.so
 test/tmp
+test/config/logs/
+test/config/models/
 /*.yaml
 examples/preproc/

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -8,7 +8,8 @@ Prerequisites
 
 Before running *xnmt* you must install the required packages, including Python bindings for
 `DyNet <http://github.com/clab/dynet>`_.
-This can be done by running ``pip install -r requirements.txt``
+This can be done by running ``pip install -r requirements.txt``.
+(There is also ``requirements-extra.txt`` that has some requirements for utility scripts that are not part of *xnmt* itself.)
 
 Next, install *xnmt* by running ``python setup.py install`` for normal usage or ``python setup.py develop`` for
 development.

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -1,0 +1,1 @@
+librosa

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ lxml
 dynet    
 matplotlib    
 cython   
-librosa==0.6.0
-h5py==2.7.1
+h5py


### PR DESCRIPTION
Fixes https://github.com/neulab/xnmt/issues/329

Looks like all tests and training pass without librosa and exact h5 version, so here is a cleanup. Also small addition to gitignore for the test directory.