### PR TITLE
xnmt shortcut

### DIFF
--- a/docs/experiment_config_files.rst
+++ b/docs/experiment_config_files.rst
@@ -52,10 +52,8 @@ be over-written by the name of the experiment, ``{EXP_DIR}`` will be overwritten
 by the directory the config file lies in, ``{PID}`` by the process id, and
 ``{GIT_REV}`` by the current git revision.
 
-To obtain a full list of allowed parameters, please check the constructor of
-``ExpGlobal``, specified under xnmt/exp_global.py. Behind the scenes, this class
-also manages the DyNet parameters, it is therefore referenced by all components
-that use DyNet parameters.
+To obtain a full list of allowed parameters, please check the documentation for
+:class:`xnmt.exp_global.ExpGlobal`.
 
 Preprocessing
 =============
@@ -97,10 +95,7 @@ Note that some of this Python objects are passed to their parent object's
 initializer method, which requires that the children are initialized first.
 *xnmt* therefore uses a bottom-up initialization strategy, where siblings
 are initialized in the order they appear in the constructor. Among others,
-this causes ``exp_global`` (the first child of the top-level experiment) to be
-initialized before any model component is initialized, so that model components
-are free to use exp_global's global default settings, DyNet parameters, etc.
-It also guarantees that preprocessing is carried out before the model training.
+this guarantees that preprocessing is carried out before the model training.
 
 Training
 ========

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -6,12 +6,13 @@ Prerequisites
 
 *xnmt* requires Python 3.6.
 
-Before running *xnmt*, it must be installed by running ``python setup.py install`` for normal usage or
-``python setup.py develop`` for development (the latter allows changing code without re-running install).
-This will also install the required packages (including Python bindings for `DyNet <http://github.com/clab/dynet>`_)
-from requirements.txt, which can also be manually installed by typing ``pip install -r requirements.txt``.
-(There is also ``requirements-extra.txt`` that has some requirements for utility scripts that are not part of *xnmt*
-itself.)
+Before running *xnmt* you must install the required packages, including Python bindings for
+`DyNet <http://github.com/clab/dynet>`_.
+This can be done by running ``pip install -r requirements.txt``.
+(There is also ``requirements-extra.txt`` that has some requirements for utility scripts that are not part of *xnmt* itself.)
+
+Next, install *xnmt* by running ``python setup.py install`` for normal usage or ``python setup.py develop`` for
+development.
 
 Running the examples
 --------------------

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -6,13 +6,12 @@ Prerequisites
 
 *xnmt* requires Python 3.6.
 
-Before running *xnmt* you must install the required packages, including Python bindings for
-`DyNet <http://github.com/clab/dynet>`_.
-This can be done by running ``pip install -r requirements.txt``.
-(There is also ``requirements-extra.txt`` that has some requirements for utility scripts that are not part of *xnmt* itself.)
-
-Next, install *xnmt* by running ``python setup.py install`` for normal usage or ``python setup.py develop`` for
-development.
+Before running *xnmt*, it must be installed by running ``python setup.py install`` for normal usage or
+``python setup.py develop`` for development (the latter allows changing code without re-running install).
+This will also install the required packages (including Python bindings for `DyNet <http://github.com/clab/dynet>`_)
+from requirements.txt, which can also be manually installed by typing ``pip install -r requirements.txt``.
+(There is also ``requirements-extra.txt`` that has some requirements for utility scripts that are not part of *xnmt*
+itself.)
 
 Running the examples
 --------------------
@@ -21,8 +20,9 @@ Running the examples
 These are a good starting point to get familiarized with specifying models and
 experiments. To run the first experiment, use the following::
 
-    python -m xnmt.xnmt_run_experiments examples/01_standard.yaml
+    xnmt examples/01_standard.yaml
 
+This is a shortcut for typing ``python -m xnmt.xnmt_run_experiments examples/01_standard.yaml``.
 Make sure to read the comments provided in ``examples/01_standard.yaml``.
 
 See the ``experiment-config-files`` documentation entry for more details about writing experiment configuration files.

--- a/examples/03_multiple_exp.yaml
+++ b/examples/03_multiple_exp.yaml
@@ -4,7 +4,7 @@
 # It's also possible to run experiments in parallel:
 # by default, experiments are skipped when the corresponding log file already
 # exists, i.e. when the experiment is currently running or has already finnished.
-# That means it's safe to run xnmt.xnmt_run_experiments on the same config file
+# That means it's safe to run ``xnmt my_config.yaml`` on the same config file
 # multiple times.
 #
 # This particular examples runs the same experiment, changing only the amount

--- a/examples/04_settings.yaml
+++ b/examples/04_settings.yaml
@@ -4,7 +4,7 @@
 # exists, and whether to activate the DyNet check_validity and immediate_compute options.
 # 
 # As the name suggests, e.g. when debugging one might use XNMT as follows:
-# python -m xnmt.xnmt_run_experiments --settings=debug examples/04_settings.yaml
+# ``xnmt --settings=debug examples/04_settings.yaml``
 # 
 # It is easy to change behavior by either changing these configurations, or adding a new configuration to the module.
 settings-exp: !Experiment

--- a/recipes/stanford-iwslt/README
+++ b/recipes/stanford-iwslt/README
@@ -2,7 +2,7 @@ This trains a neural machine translation model on the IWSLT English-Vietnamese d
 
 Steps:
 - ./download.sh
-- python -m xnmt.xnmt_run_experiments --dynet-gpu ./config.en-vi.yaml
+- xnmt --dynet-gpu ./config.en-vi.yaml
 
 Reference output after the final evaluation:
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
   url='https://github.com/neulab/xnmt',
   license='Apache License',
   install_requires=install_requires,
-  packages=find_packages(exclude=['test*']),
+  packages=find_packages(exclude=['test*', 'xnmt.cython', 'xnmt.test']),
   ext_modules=ext_modules,
   python_requires='>=3.6',
   project_urls={

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 from distutils.core import Extension
 import sys
 
@@ -27,12 +27,21 @@ setup(
   version='0.0.1',
   description='eXtensible Neural Machine Translation',
   author='neulab',
+  url='https://github.com/neulab/xnmt',
   license='Apache License',
   install_requires=install_requires,
-  packages=[
-      'xnmt',
-      'xnmt.speech_features',
-  ],
+  packages=find_packages(exclude=['test*']),
   ext_modules=ext_modules,
+  python_requires='>=3.6',
+  project_urls={
+    'Documentation': 'http://xnmt.readthedocs.io/en/latest/',
+    'Source': 'https://github.com/neulab/xnmt',
+    'Tracker': 'https://github.com/neulab/xnmt/issues',
+  },
+  entry_points={
+    'console_scripts': [
+      'xnmt = xnmt.xnmt_run_experiments:main',
+      'xnmt_evaluate = xnmt.xnmt_run_experiments:main',
+    ],
+  }
 )
-

--- a/xnmt/xnmt_evaluate.py
+++ b/xnmt/xnmt_evaluate.py
@@ -1,5 +1,6 @@
-from typing import Any, Sequence
 import argparse
+import sys
+from typing import Any, Sequence
 
 from xnmt import logger
 from xnmt.evaluator import * # import everything so we can parse it with eval()
@@ -50,7 +51,7 @@ def xnmt_evaluate(ref_file: OneOrSeveral[str], hyp_file: OneOrSeveral[str],
 
   return [evaluator.evaluate(ref_corpus, hyp_corpus, desc=desc) for evaluator in evaluators]
 
-if __name__ == "__main__":
+def main():
   parser = argparse.ArgumentParser()
   parser.add_argument("ref", help="Path to read reference file from")
   parser.add_argument("hyp", help="Path to read hypothesis file from")
@@ -71,3 +72,5 @@ if __name__ == "__main__":
   for score in scores:
     print(score)
 
+if __name__ == "__main__":
+  sys.exit(main())


### PR DESCRIPTION
This allows typing ```xnmt``` instead of ```python -m xnmt.xnmt_run_experiments```, and ```xnmt_evaluate``` instead of ```python -m xnmt.xnmt_evaluate``` after running setup.py.