### PR TITLE
[WIP] Added ability to combine together dev scores

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ dynet
 matplotlib    
 cython   
 h5py
+asteval
 sentencepiece>=0.0.6

--- a/test/config/dev_combinator.yaml
+++ b/test/config/dev_combinator.yaml
@@ -1,0 +1,35 @@
+# A standard training run, should almost never break
+dev_combinator: !Experiment
+  exp_global: !ExpGlobal
+    model_file: examples/output/{EXP}.mod
+    log_file: examples/output/{EXP}.log
+    default_layer_dim: 64
+  model: !DefaultTranslator
+    src_reader: !PlainTextReader
+      vocab: !Vocab {vocab_file: examples/data/head.ja.vocab}
+    trg_reader: !PlainTextReader
+      vocab: !Vocab {vocab_file: examples/data/head.en.vocab}
+    search_strategy: !BeamSearch
+      beam_size: 5
+  train: !SimpleTrainingRegimen
+    run_for_epochs: 2
+    src_file: examples/data/head.ja
+    trg_file: examples/data/head.en
+    dev_tasks:
+      - !AccuracyEvalTask
+        eval_metrics: bleu
+        src_file: examples/data/head.ja
+        ref_file: examples/data/head.en
+        hyp_file: examples/output/{EXP}.test_hyp
+      - !LossEvalTask
+        src_file: examples/data/head.ja
+        ref_file: examples/data/head.en
+    dev_combinator: "x[0]-x[1]"
+  evaluate:
+    - !AccuracyEvalTask
+      eval_metrics: bleu
+      src_file: examples/data/head.ja
+      ref_file: examples/data/head.en
+      hyp_file: examples/output/{EXP}.test_hyp
+
+      

--- a/xnmt/evaluator.py
+++ b/xnmt/evaluator.py
@@ -61,7 +61,7 @@ class BLEUScore(EvalScore, Serializable):
     self.serialize_params = {"bleu":bleu, "ngram":ngram}
     self.serialize_params.update({k:getattr(self,k) for k in ["frac_score_list","brevity_penalty_score","hyp_len","ref_len","desc"] if getattr(self,k) is not None})
 
-  def value(self): return self.bleu
+  def value(self): return self.bleu if self.bleu != None else 0.0
   def metric_name(self): return "BLEU" + str(self.ngram)
   def higher_is_better(self): return True
   def score_str(self):

--- a/xnmt/training_regimen.py
+++ b/xnmt/training_regimen.py
@@ -55,11 +55,11 @@ class SimpleTrainingRegimen(SimpleTrainingTask, TrainingRegimen, Serializable):
     patience (int): apply LR decay after dev scores haven't improved over this many checkpoints
     initial_patience (int): if given, allows adjusting patience for the first LR decay
     dev_tasks (List[EvalTask]): A list of tasks to use during the development stage.
-    dev_combinator (str): A formula to combine together development scores into a single score to
-                          choose whether to perform learning rate decay, etc.
-                          e.g. 'x[0]-x[1]' would say that the first dev task score minus the
-                          second dev task score is our measure of how good we're doing. If not
-                          specified, only the score from the first dev task will be used.
+    dev_combinator: A formula to combine together development scores into a single score to
+                    choose whether to perform learning rate decay, etc.
+                    e.g. 'x[0]-x[1]' would say that the first dev task score minus the
+                    second dev task score is our measure of how good we're doing. If not
+                    specified, only the score from the first dev task will be used.
     restart_trainer (bool): Restart trainer (useful for Adam) and revert weights to best dev checkpoint when applying LR decay (https://arxiv.org/pdf/1706.09733.pdf)
     reload_command (str): Command to change the input data after each epoch.
                          --epoch EPOCH_NUM will be appended to the command.
@@ -77,7 +77,7 @@ class SimpleTrainingRegimen(SimpleTrainingTask, TrainingRegimen, Serializable):
   def __init__(self, model=Ref("model"), src_file=None, trg_file=None, dev_every=0, dev_zero=False,
                batcher=bare(xnmt.batcher.SrcBatcher, batch_size=32), loss_calculator=bare(MLELoss), trainer=None,
                run_for_epochs=None, lr_decay=1.0, lr_decay_times=3, patience=1, initial_patience=None, dev_tasks=None,
-               dev_combinator: str=None, restart_trainer: bool = False,
+               dev_combinator=None, restart_trainer: bool = False,
                reload_command=None, name="{EXP}", sample_train_sents=None,
                max_num_train_sents=None, max_src_len=None, max_trg_len=None,
                commandline_args=Ref("exp_global.commandline_args", default=None)):

--- a/xnmt/training_regimen.py
+++ b/xnmt/training_regimen.py
@@ -55,6 +55,11 @@ class SimpleTrainingRegimen(SimpleTrainingTask, TrainingRegimen, Serializable):
     patience (int): apply LR decay after dev scores haven't improved over this many checkpoints
     initial_patience (int): if given, allows adjusting patience for the first LR decay
     dev_tasks (List[EvalTask]): A list of tasks to use during the development stage.
+    dev_combinator (str): A formula to combine together development scores into a single score to
+                          choose whether to perform learning rate decay, etc.
+                          e.g. 'x[0]-x[1]' would say that the first dev task score minus the
+                          second dev task score is our measure of how good we're doing. If not
+                          specified, only the score from the first dev task will be used.
     restart_trainer (bool): Restart trainer (useful for Adam) and revert weights to best dev checkpoint when applying LR decay (https://arxiv.org/pdf/1706.09733.pdf)
     reload_command (str): Command to change the input data after each epoch.
                          --epoch EPOCH_NUM will be appended to the command.
@@ -72,7 +77,8 @@ class SimpleTrainingRegimen(SimpleTrainingTask, TrainingRegimen, Serializable):
   def __init__(self, model=Ref("model"), src_file=None, trg_file=None, dev_every=0, dev_zero=False,
                batcher=bare(xnmt.batcher.SrcBatcher, batch_size=32), loss_calculator=bare(MLELoss), trainer=None,
                run_for_epochs=None, lr_decay=1.0, lr_decay_times=3, patience=1, initial_patience=None, dev_tasks=None,
-               restart_trainer: bool = False, reload_command=None, name="{EXP}", sample_train_sents=None,
+               dev_combinator: str=None, restart_trainer: bool = False,
+               reload_command=None, name="{EXP}", sample_train_sents=None,
                max_num_train_sents=None, max_src_len=None, max_trg_len=None,
                commandline_args=Ref("exp_global.commandline_args", default=None)):
 
@@ -88,6 +94,7 @@ class SimpleTrainingRegimen(SimpleTrainingTask, TrainingRegimen, Serializable):
                      patience=patience,
                      initial_patience=initial_patience,
                      dev_tasks=dev_tasks,
+                     dev_combinator=dev_combinator,
                      restart_trainer=restart_trainer,
                      reload_command=reload_command,
                      name=name,

--- a/xnmt/training_task.py
+++ b/xnmt/training_task.py
@@ -1,5 +1,6 @@
 from subprocess import Popen
 import random
+import parser
 import numpy as np
 from typing import Optional
 
@@ -83,6 +84,11 @@ class SimpleTrainingTask(TrainingTask, Serializable):
     patience (int): apply LR decay after dev scores haven't improved over this many checkpoints
     initial_patience (int): if given, allows adjusting patience for the first LR decay
     dev_tasks: A list of tasks to run on the development set
+    dev_combinator (str): A formula to combine together development scores into a single score to
+                          choose whether to perform learning rate decay, etc.
+                          e.g. 'x[0]-x[1]' would say that the first dev task score minus the
+                          second dev task score is our measure of how good we're doing. If not
+                          specified, only the score from the first dev task will be used.
     restart_trainer: Restart trainer (useful for Adam) and revert weights to best dev checkpoint when applying LR decay (https://arxiv.org/pdf/1706.09733.pdf)
     reload_command: Command to change the input data after each epoch.
                          --epoch EPOCH_NUM will be appended to the command.
@@ -99,12 +105,13 @@ class SimpleTrainingTask(TrainingTask, Serializable):
   def __init__(self, model, src_file=None, trg_file=None, dev_every=0,
                batcher=bare(SrcBatcher, batch_size=32), loss_calculator=bare(MLELoss),
                run_for_epochs=None, lr_decay=1.0, lr_decay_times=3, patience=1,
-               initial_patience=None, dev_tasks=None, restart_trainer=False,
+               initial_patience=None, dev_tasks=None, dev_combinator=None, restart_trainer=False,
                reload_command=None, name=None, sample_train_sents: Optional[int] = None,
                max_num_train_sents=None, max_src_len=None, max_trg_len=None):
     self.src_file = src_file
     self.trg_file = trg_file
     self.dev_tasks = dev_tasks
+    self.dev_combinator = dev_combinator
 
     if lr_decay > 1.0 or lr_decay <= 0.0:
       raise RuntimeError("illegal lr_decay, must satisfy: 0.0 < lr_decay <= 1.0")
@@ -275,9 +282,9 @@ class SimpleTrainingTask(TrainingTask, Serializable):
     """
     # Perform evaluation
     if self.dev_tasks and len(self.dev_tasks) > 0:
+      dev_scores = []
       with self.dev_loss_tracker.time_tracker:
         logger.info("> Checkpoint")
-        dev_scores = []
         for dev_task in self.dev_tasks:
           dev_score, dev_word_cnt = dev_task.eval()
           if type(dev_score) == list:
@@ -291,9 +298,20 @@ class SimpleTrainingTask(TrainingTask, Serializable):
 
       # Control the learning schedule
       if control_learning_schedule:
-        # Write out the model if it's the best one
-        if dev_scores[0].better_than(self.training_state.best_dev_score):
+        # Check if this is the best
+        is_best = False
+        if self.dev_combinator != None:
+          x = [y.value() for y in dev_scores]
+          # TODO: This is a security hole!
+          my_score = eval(self.dev_combinator)
+          if self.training_state.best_dev_score == None or my_score > self.training_state.best_dev_score:
+            self.training_state.best_dev_score = my_score
+            is_best = True
+        elif dev_scores[0].better_than(self.training_state.best_dev_score):
           self.training_state.best_dev_score = dev_scores[0]
+          is_best = True
+        # If this is the best, write the model out
+        if is_best:
           self.training_state.cur_attempt = 0
           needs_saving = True
           logger.info(f"  best dev score, writing out model")


### PR DESCRIPTION
This PR introduces the ability to combine together multiple development scores to determine the final score that should be used to do learning rate decay, etc. It also improves the documentation about the default of using the first development task.

The reason why this is "[WIP]" is because using `eval()` is a security hole: https://stackoverflow.com/questions/661084/security-of-pythons-eval-on-untrusted-strings

It'd be nice to be able to come up with a safe version.

Fixes https://github.com/neulab/xnmt/issues/293