### PR TITLE
Fix avg batch size

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ matplotlib
 cython   
 h5py
 asteval
-sentencepiece>=0.0.6
+numpy

--- a/xnmt/batcher.py
+++ b/xnmt/batcher.py
@@ -7,8 +7,11 @@ from xnmt.persistence import serializable_init, Serializable
 
 class Batch(list):
   """
-  Specialization of list that indicates a (mini)batch of things, together with an optional mask.
-  Should be treated as immutable object.
+  A class containing a minibatch of things.
+
+  This class behaves like a Python list, but adds semantics that the contents form a (mini)batch of things.
+  An optional mask can be specified to indicate padded parts of the inputs.
+  Should be treated as an immutable object.
   
   Args:
     batch_list (list): list of things
@@ -20,6 +23,8 @@ class Batch(list):
 
 class Mask(object):
   """
+  A mask specifies padded parts in a sequence or batch of sequences.
+
   Masks are represented as numpy array of dimensions batchsize x seq_len, with parts
   belonging to the sequence set to 0, and parts that should be masked set to 1
   
@@ -78,7 +83,14 @@ class Mask(object):
 
 class Batcher(object):
   """
-  A template class to convert a list of sents to several batches of sents.
+  A template class to convert a list of sentences to several batches of sentences.
+
+  Args:
+    batch_size (int): batch size
+    granularity (str): 'sent' or 'word'
+    src_pad_token: token used to pad on source side
+    trg_pad_token: token used to pad on target side
+    pad_src_to_multiple (int): pad source sentences so its length is multiple of this integer.
   """
 
   def __init__(self, batch_size, granularity='sent', src_pad_token=Vocab.ES, trg_pad_token=Vocab.ES,
@@ -92,7 +104,7 @@ class Batcher(object):
   def is_random(self):
     """
     Returns:
-      True if there is some randomness in the batching process, False otherwise. Defaults to false.
+      True if there is some randomness in the batching process, False otherwise.
     """
     return False
 
@@ -130,10 +142,10 @@ class InOrderBatcher(Batcher, Serializable):
   A class to create batches in order of the original corpus.
   
   Args:
-    batch_size (int): number of sents in each batch
-    src_pad_token: padding token on src side
-    trg_pad_token: padding token on trg side
-    pad_src_to_multiple (int): pad the source side so that the batch length is a multiple of the specified integer
+    batch_size (int): batch size
+    src_pad_token: token used to pad on source side
+    trg_pad_token: token used to pad on target side
+    pad_src_to_multiple (int): pad source sentences so its length is multiple of this integer.
   """
   yaml_tag = "!InOrderBatcher"
 
@@ -163,7 +175,7 @@ class ShuffleBatcher(Batcher):
 
 class SortBatcher(Batcher):
   """
-  A template class to create batches through bucketing sent length.
+  A template class to create batches through bucketing sentence length.
   """
   __tiebreaker_eps = 1.0e-7
 
@@ -188,6 +200,15 @@ class SortBatcher(Batcher):
 
 # Module level functions
 def mark_as_batch(data, mask=None):
+  """
+  Mark a sequence of items as batch
+
+  Args:
+    data: sequence of things
+    mask: optional mask
+
+  Returns: a batch of things
+  """
   if type(data) == Batch and mask is None:
     ret = data
   else:
@@ -195,9 +216,29 @@ def mark_as_batch(data, mask=None):
   return ret
 
 def is_batched(data):
+  """
+  Check whether some data is batched.
+
+  Args:
+    data: data to check
+
+  Returns:
+    True iff data is batched.
+  """
   return type(data) == Batch
 
 def pad(batch, pad_token=Vocab.ES, pad_src_to_multiple=1):
+  """
+  Apply padding to sentences in a batch.
+
+  Args:
+    batch: batch of sentences
+    pad_token: token to pad with
+    pad_src_to_multiple (int): pad source sentences so its length is multiple of this integer.
+
+  Returns:
+    Tuple: list of padded items and a corresponding batched mask.
+  """
   max_len = max(len_or_zero(item) for item in batch)
   if max_len % pad_src_to_multiple != 0:
     max_len += pad_src_to_multiple - (max_len % pad_src_to_multiple)
@@ -219,11 +260,11 @@ class SrcBatcher(SortBatcher, Serializable):
   A batcher that creates fixed-size batches, grouped by src len.
   
   Args:
-    batch_size (int): number of sents in each batch
-    src_pad_token: padding token on src side
-    trg_pad_token: padding token on trg side
+    batch_size (int): batch size
+    src_pad_token: token used to pad on source side
+    trg_pad_token: token used to pad on target side
     break_ties_randomly (bool): if True, randomly shuffle sentences of the same src length before creating batches.
-    pad_src_to_multiple (int): pad the source side so that the batch length is a multiple of the specified integer
+    pad_src_to_multiple (int): pad source sentences so its length is multiple of this integer.
   """
   yaml_tag = "!SrcBatcher"
 
@@ -240,11 +281,11 @@ class TrgBatcher(SortBatcher, Serializable):
   A batcher that creates fixed-size batches, grouped by trg len.
   
   Args:
-    batch_size (int): number of sents in each batch
-    src_pad_token: padding token on src side
-    trg_pad_token: padding token on trg side
-    break_ties_randomly (bool): if True, randomly shuffle sentences of the same trg length before creating batches.
-    pad_src_to_multiple (int): pad the source side so that the batch length is a multiple of the specified integer
+    batch_size (int): batch size
+    src_pad_token: token used to pad on source side
+    trg_pad_token: token used to pad on target side
+    break_ties_randomly (bool): if True, randomly shuffle sentences of the same src length before creating batches.
+    pad_src_to_multiple (int): pad source sentences so its length is multiple of this integer.
   """
   yaml_tag = "!TrgBatcher"
 
@@ -261,11 +302,11 @@ class SrcTrgBatcher(SortBatcher, Serializable):
   A batcher that creates fixed-size batches, grouped by src len, then trg len.
   
   Args:
-    batch_size (int): number of sents in each batch
-    src_pad_token: padding token on src side
-    trg_pad_token: padding token on trg side
-    break_ties_randomly (bool): if True, randomly shuffle sentences of the same src and trg len before creating batches.
-    pad_src_to_multiple (int): pad the source side so that the batch length is a multiple of the specified integer
+    batch_size (int): batch size
+    src_pad_token: token used to pad on source side
+    trg_pad_token: token used to pad on target side
+    break_ties_randomly (bool): if True, randomly shuffle sentences of the same src length before creating batches.
+    pad_src_to_multiple (int): pad source sentences so its length is multiple of this integer.
   """
   yaml_tag = "!SrcTrgBatcher"
 
@@ -283,11 +324,11 @@ class TrgSrcBatcher(SortBatcher, Serializable):
   A batcher that creates fixed-size batches, grouped by trg len, then src len.
   
   Args:
-    batch_size (int): number of sents in each batch
-    src_pad_token: padding token on src side
-    trg_pad_token: padding token on trg side
-    break_ties_randomly (bool): if True, randomly shuffle sentences of the same src and trg length before creating batches.
-    pad_src_to_multiple (int): pad the source side so that the batch length is a multiple of the specified integer
+    batch_size (int): batch size
+    src_pad_token: token used to pad on source side
+    trg_pad_token: token used to pad on target side
+    break_ties_randomly (bool): if True, randomly shuffle sentences of the same src length before creating batches.
+    pad_src_to_multiple (int): pad source sentences so its length is multiple of this integer.
   """
   yaml_tag = "!TrgSrcBatcher"
 
@@ -305,10 +346,10 @@ class SentShuffleBatcher(ShuffleBatcher, Serializable):
   A batcher that creates fixed-size batches or random order.
   
   Args:
-    batch_size (int): number of sents in each batch
-    src_pad_token: padding token on src side
-    trg_pad_token: padding token on trg side
-    pad_src_to_multiple (int): pad the source side so that the batch length is a multiple of the specified integer
+    batch_size (int): batch size
+    src_pad_token: token used to pad on source side
+    trg_pad_token: token used to pad on target side
+    pad_src_to_multiple (int): pad source sentences so its length is multiple of this integer.
   """
   yaml_tag = "!SentShuffleBatcher"
 
@@ -323,11 +364,10 @@ class WordShuffleBatcher(ShuffleBatcher, Serializable):
   A batcher that creates fixed-size batches, grouped by src len.
   
   Args:
-    batch_size (int): number of sents in each batch
-    src_pad_token: padding token on src side
-    trg_pad_token: padding token on trg side
-    break_ties_randomly (bool): if True, randomly shuffle sentences of the same src length before creating batches.
-    pad_src_to_multiple (int): pad the source side so that the batch length is a multiple of the specified integer
+    words_per_batch (int): number of src+trg words in each batch
+    src_pad_token: token used to pad on source side
+    trg_pad_token: token used to pad on target side
+    pad_src_to_multiple (int): pad source sentences so its length is multiple of this integer.
   """
   yaml_tag = "!WordShuffleBatcher"
 
@@ -361,12 +401,12 @@ class WordSrcBatcher(WordSortBatcher, Serializable):
   A batcher that creates variable-sized batches with given average (src+trg) words per batch, grouped by src len.
   
   Args:
-    words_per_batch (int): number of src words in each batch
-    avg_batch_size (number): avg number of sents in each batch (if words_per_batch not given)
-    src_pad_token: padding token on src side
-    trg_pad_token: padding token on trg side
+    words_per_batch (int): number of src+trg words in each batch
+    avg_batch_size (number): avg number of sentences in each batch (if words_per_batch not given)
+    src_pad_token: token used to pad on source side
+    trg_pad_token: token used to pad on target side
     break_ties_randomly (bool): if True, randomly shuffle sentences of the same src length before creating batches.
-    pad_src_to_multiple (int): pad the source side so that the batch length is a multiple of the specified integer
+    pad_src_to_multiple (int): pad source sentences so its length is multiple of this integer.
   """
   yaml_tag = "!WordSrcBatcher"
 
@@ -389,12 +429,12 @@ class WordTrgBatcher(WordSortBatcher, Serializable):
   A batcher that creates variable-sized batches with given average (src+trg) words per batch, grouped by trg len.
   
   Args:
-    words_per_batch (int): number of trg words in each batch
-    avg_batch_size (number): avg number of sents in each batch (if words_per_batch not given)
-    src_pad_token: padding token on src side
-    trg_pad_token: padding token on trg side
-    break_ties_randomly (bool): if True, randomly shuffle sentences of the same trg length before creating batches.
-    pad_src_to_multiple (int): pad the source side so that the batch length is a multiple of the specified integer
+    words_per_batch (int): number of src+trg words in each batch
+    avg_batch_size (number): avg number of sentences in each batch (if words_per_batch not given)
+    src_pad_token: token used to pad on source side
+    trg_pad_token: token used to pad on target side
+    break_ties_randomly (bool): if True, randomly shuffle sentences of the same src length before creating batches.
+    pad_src_to_multiple (int): pad source sentences so its length is multiple of this integer.
   """
   yaml_tag = "!WordTrgBatcher"
 
@@ -417,12 +457,12 @@ class WordSrcTrgBatcher(WordSortBatcher, Serializable):
   A batcher that creates variable-sized batches with given average number of src + trg words per batch, grouped by src len, then trg len.
   
   Args:
-    words_per_batch (int): number of src + trg words in each batch
-    avg_batch_size (number): avg number of sents in each batch (if words_per_batch not given)
-    src_pad_token: padding token on src side
-    trg_pad_token: padding token on trg side
-    break_ties_randomly (bool): if True, randomly shuffle sentences of the same src and trg length before creating batches.
-    pad_src_to_multiple (int): pad the source side so that the batch length is a multiple of the specified integer
+    words_per_batch (int): number of src+trg words in each batch
+    avg_batch_size (number): avg number of sentences in each batch (if words_per_batch not given)
+    src_pad_token: token used to pad on source side
+    trg_pad_token: token used to pad on target side
+    break_ties_randomly (bool): if True, randomly shuffle sentences of the same src length before creating batches.
+    pad_src_to_multiple (int): pad source sentences so its length is multiple of this integer.
   """
   yaml_tag = "!WordSrcTrgBatcher"
 
@@ -445,12 +485,12 @@ class WordTrgSrcBatcher(WordSortBatcher, Serializable):
   A batcher that creates variable-sized batches with given average number of src + trg words per batch, grouped by trg len, then src len.
   
   Args:
-    words_per_batch (int): number of src + trg words in each batch
-    avg_batch_size (number): avg number of sents in each batch (if words_per_batch not given)
-    src_pad_token: padding token on src side
-    trg_pad_token: padding token on trg side
-    break_ties_randomly (bool): if True, randomly shuffle sentences of the same src and trg length before creating batches.
-    pad_src_to_multiple (int): pad the source side so that the batch length is a multiple of the specified integer
+    words_per_batch (int): number of src+trg words in each batch
+    avg_batch_size (number): avg number of sentences in each batch (if words_per_batch not given)
+    src_pad_token: token used to pad on source side
+    trg_pad_token: token used to pad on target side
+    break_ties_randomly (bool): if True, randomly shuffle sentences of the same src length before creating batches.
+    pad_src_to_multiple (int): pad source sentences so its length is multiple of this integer.
   """
   yaml_tag = "!WordTrgSrcBatcher"
 

--- a/xnmt/batcher.py
+++ b/xnmt/batcher.py
@@ -358,7 +358,7 @@ class WordSortBatcher(SortBatcher):
 
 class WordSrcBatcher(WordSortBatcher, Serializable):
   """
-  A batcher that creates variable-sized batches with given average (src) words per batch, grouped by src len.
+  A batcher that creates variable-sized batches with given average (src+trg) words per batch, grouped by src len.
   
   Args:
     words_per_batch (int): number of src words in each batch
@@ -381,12 +381,12 @@ class WordSrcBatcher(WordSortBatcher, Serializable):
 
   def pack_by_order(self, src, trg, order):
     if self.avg_batch_size:
-      self.batch_size = sum([len(s) for s in src]) / len(src) * self.avg_batch_size
+      self.batch_size = (sum([len(s) for s in src]) + sum([len(s) for s in trg])) / len(src) * self.avg_batch_size
     return super(WordSrcBatcher, self).pack_by_order(src, trg, order)
 
 class WordTrgBatcher(WordSortBatcher, Serializable):
   """
-  A batcher that creates variable-sized batches with given average (trg) words per batch, grouped by trg len.
+  A batcher that creates variable-sized batches with given average (src+trg) words per batch, grouped by trg len.
   
   Args:
     words_per_batch (int): number of trg words in each batch
@@ -409,7 +409,7 @@ class WordTrgBatcher(WordSortBatcher, Serializable):
 
   def pack_by_order(self, src, trg, order):
     if self.avg_batch_size:
-      self.batch_size = sum([len(s) for s in trg]) / len(trg) * self.avg_batch_size
+      self.batch_size = (sum([len(s) for s in src]) + sum([len(s) for s in trg])) / len(src) * self.avg_batch_size
     return super(WordTrgBatcher, self).pack_by_order(src, trg, order)
 
 class WordSrcTrgBatcher(WordSortBatcher, Serializable):
@@ -437,7 +437,7 @@ class WordSrcTrgBatcher(WordSortBatcher, Serializable):
 
   def pack_by_order(self, src, trg, order):
     if self.avg_batch_size:
-      self.batch_size = sum([len(s) for s in src]) / len(src) * self.avg_batch_size
+      self.batch_size = (sum([len(s) for s in src]) + sum([len(s) for s in trg])) / len(src) * self.avg_batch_size
     return super(WordSrcTrgBatcher, self).pack_by_order(src, trg, order)
 
 class WordTrgSrcBatcher(WordSortBatcher, Serializable):
@@ -465,6 +465,6 @@ class WordTrgSrcBatcher(WordSortBatcher, Serializable):
 
   def pack_by_order(self, src, trg, order):
     if self.avg_batch_size:
-      self.batch_size = sum([len(s) for s in trg]) / len(trg) * self.avg_batch_size
+      self.batch_size = (sum([len(s) for s in src]) + sum([len(s) for s in trg])) / len(src) * self.avg_batch_size
     return super(WordTrgSrcBatcher, self).pack_by_order(src, trg, order)
 


### PR DESCRIPTION
When using avg_batch_size, the corresponding number of words per batch was first computed by considering source words only, but then later when building the batches the sum of source + target words were counted. This is a fix to consistently use the sum of source + target words.

Also improves the batcher doc a little bit and fixes requirements as pointed out by @pierregodard .