### PR TITLE
Reorganize set_train()

### DIFF
--- a/xnmt/eval_task.py
+++ b/xnmt/eval_task.py
@@ -55,6 +55,7 @@ class LossEvalTask(Serializable):
     self.desc=desc
 
   def eval(self):
+    self.model.set_train(False)
     if self.src_data == None:
       self.src_data, self.ref_data, self.src_batches, self.ref_batches = \
         xnmt.input_reader.read_parallel_corpus(self.model.src_reader, self.model.trg_reader,
@@ -115,6 +116,7 @@ class AccuracyEvalTask(Serializable):
     self.desc=desc
 
   def eval(self):
+    self.model.set_train(False)
     self.inference(generator = self.model,
                    src_file = self.src_file,
                    trg_file = self.hyp_file,


### PR DESCRIPTION
Previously the training regimen was in control of calling ```set_train()``` to switch between training and eval steps, but that led to some inconsistency when the training regimen was skipped (e.g. when setting ```run_for_epochs=0```). This PR moves calls to ```set_train()``` closer to where they are actually needed in the code in the hope of avoiding some of these side effect issues.