### PR TITLE
Add inference to transformer config

### DIFF
--- a/examples/16_transformer.yaml
+++ b/examples/16_transformer.yaml
@@ -17,6 +17,7 @@ transformer: !Experiment
       vocab: !Vocab {vocab_file: examples/data/head.ja.vocab}
     trg_reader: !PlainTextReader
       vocab: !Vocab {vocab_file: examples/data/head.en.vocab}
+    inference: !SimpleInference {}
   train: !SimpleTrainingRegimen
     run_for_epochs: 30
     batcher: !SentShuffleBatcher


### PR DESCRIPTION
The Transformer example config file didn't have an inference object specified, so it was raising an exception during training.