### PR TITLE
Sentence level evaluation

### DIFF
--- a/docs/api_doc.rst
+++ b/docs/api_doc.rst
@@ -18,10 +18,10 @@ Experiment
 Model
 -----
 
-GeneratorModel
-~~~~~~~~~~~~~~
+Model Base Classes
+~~~~~~~~~~~~~~~~~~
 
-.. automodule:: xnmt.generator
+.. automodule:: xnmt.model_base
    :members:
    :show-inheritance:
 

--- a/examples/13_speech.yaml
+++ b/examples/13_speech.yaml
@@ -67,7 +67,7 @@ speech: !Experiment
     - !AccuracyEvalTask
       eval_metrics: cer,wer
       src_file: examples/data/LDC94S13A.h5
-      ref_file: [examples/data/LDC94S13A.words, examples/data/LDC94S13A.words]
+      ref_file: examples/data/LDC94S13A.words
       hyp_file: examples/output/{EXP}.test_hyp
       inference: !SimpleInference
         post_process: join-char

--- a/examples/13_speech.yaml
+++ b/examples/13_speech.yaml
@@ -67,7 +67,7 @@ speech: !Experiment
     - !AccuracyEvalTask
       eval_metrics: cer,wer
       src_file: examples/data/LDC94S13A.h5
-      ref_file: examples/data/LDC94S13A.words
+      ref_file: [examples/data/LDC94S13A.words, examples/data/LDC94S13A.words]
       hyp_file: examples/output/{EXP}.test_hyp
       inference: !SimpleInference
         post_process: join-char

--- a/test/test_evaluation.py
+++ b/test/test_evaluation.py
@@ -29,5 +29,37 @@ class TestBLEU(unittest.TestCase):
     act_bleu = bleu.evaluate(self.ref_id, self.hyp_id)
     self.assertEqual(act_bleu, exp_bleu)
 
+class TestGLEU(unittest.TestCase):
+  def setUp(self):
+    self.evaluator = evaluator.GLEUEvaluator()
+  def test_gleu_single_1(self):
+    self.assertAlmostEqual(
+      self.evaluator.evaluate(['the cat is on the mat'.split()], ['the the the the the the the'.split()]).value(),
+      0.0909,
+      places=4)
+  def test_gleu_single_2(self):
+    self.assertAlmostEqual(
+      self.evaluator.evaluate(
+        ['It is a guide to action that ensures that the military will forever heed Party commands'.split()], [
+          'It is a guide to action which ensures that the military always obeys the commands of the party'.split()]).value(),
+      0.4393,
+      places=3)
+  def test_gleu_single_3(self):
+    self.assertAlmostEqual(
+      self.evaluator.evaluate(
+        ['It is a guide to action that ensures that the military will forever heed Party commands'.split()], [
+          'It is to insure the troops forever hearing the activity guidebook that party direct'.split()]).value(),
+      0.1206,
+      places=3)
+  def test_gleu_corpus(self):
+    self.assertAlmostEqual(
+      self.evaluator.evaluate(
+        ['It is a guide to action that ensures that the military will forever heed Party commands'.split(),
+         'It is a guide to action that ensures that the military will forever heed Party commands'.split()], [
+          'It is a guide to action which ensures that the military always obeys the commands of the party'.split(),
+          'It is to insure the troops forever hearing the activity guidebook that party direct'.split()]).value(),
+      0.2903,
+      places=3)
+
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_evaluation.py
+++ b/test/test_evaluation.py
@@ -61,5 +61,17 @@ class TestGLEU(unittest.TestCase):
       0.2903,
       places=3)
 
+class TestSequenceAccuracy(unittest.TestCase):
+  def setUp(self):
+    self.evaluator = evaluator.SequenceAccuracyEvaluator()
+  def test_correct(self):
+    self.assertEqual(self.evaluator.evaluate(["1 2 3".split()], ["1 2 3".split()]).value(), 1.0)
+  def test_incorrect(self):
+    self.assertEqual(self.evaluator.evaluate(["2 3".split()], ["1 2 3".split()]).value(), 0.0)
+  def test_corpus(self):
+    self.assertEqual(self.evaluator.evaluate(["1 2 3".split(), "2 3".split()],
+                                             ["1 2 3".split(), "1 2 3".split()]).value(),
+                     0.5)
+
 if __name__ == '__main__':
   unittest.main()

--- a/xnmt/eval_task.py
+++ b/xnmt/eval_task.py
@@ -107,10 +107,11 @@ class AccuracyEvalTask(EvalTask, Serializable):
   def __init__(self, src_file: Union[str,Sequence[str]], ref_file: Union[str,Sequence[str]], hyp_file: str,
                model: GeneratorModel = Ref("model"), eval_metrics: Union[str, Sequence[Evaluator]] = "bleu",
                inference: Optional[SimpleInference] = None, candidate_id_file: Optional[str] = None,
-               desc: Optional[Any] = None):
+               desc: Any = None):
     self.model = model
     if isinstance(eval_metrics, str):
       eval_metrics = [xnmt.xnmt_evaluate.eval_shortcuts[shortcut]() for shortcut in eval_metrics.split(",")]
+    elif not isinstance(eval_metrics, str): eval_metrics = [eval_metrics]
     self.eval_metrics = eval_metrics
     self.src_file = src_file
     self.ref_file = ref_file

--- a/xnmt/eval_task.py
+++ b/xnmt/eval_task.py
@@ -40,8 +40,9 @@ class LossEvalTask(EvalTask, Serializable):
 
   @serializable_init
   def __init__(self, src_file: str, ref_file: str, model: GeneratorModel = Ref("model"),
-               batcher: Batcher = Ref("train.batcher", default=None), loss_calculator: LossCalculator = bare(MLELoss),
-               max_src_len: Optional[int] = None, max_trg_len: Optional[int] = None, desc: Any = None):
+               batcher: Optional[Batcher] = Ref("train.batcher", default=None),
+               loss_calculator: LossCalculator = bare(MLELoss), max_src_len: Optional[int] = None,
+               max_trg_len: Optional[int] = None, desc: Any = None):
     self.model = model
     self.loss_calculator = loss_calculator
     self.src_file = src_file

--- a/xnmt/inference.py
+++ b/xnmt/inference.py
@@ -31,10 +31,11 @@ class SimpleInference(Serializable):
     report_type: report to generate ``file/html``. Can be multiple, separate with comma.
     search_strategy: a search strategy used during decoding.
     mode: type of decoding to perform.
-            ``onebest``: generate one best.
-            ``forced``: perform forced decoding.
-            ``forceddebug``: perform forced decoding, calculate training loss, and make suer the scores are identical
-                             for debugging purposes.
+
+            * ``onebest``: generate one best.
+            * ``forced``: perform forced decoding.
+            * ``forceddebug``: perform forced decoding, calculate training loss, and make suer the scores are identical
+              for debugging purposes.
     batcher: inference batcher, needed e.g. in connection with ``pad_src_token_to_multiple``
   """
   

--- a/xnmt/levenshtein.py
+++ b/xnmt/levenshtein.py
@@ -1,0 +1,76 @@
+class LevenshteinAligner(object):
+  # gap penalty:
+  gapPenalty = -1.0
+  gapSymbol = None
+
+  # similarity function:
+  def sim(self, word1, word2):
+    if word1 == word2:
+      return 0
+    else:
+      return -1
+
+  # performs edit distance alignment between two lists
+  # outputs c, x, y, s:
+  # c = score
+  # x = l1 with gapSymbol inserted to indicate insertions
+  # y = l2 with gapSymbol inserted to indicate deletions
+  # s = list of same length as x and y, specifying correct words, substitutions,
+  #			deletions, insertions as 'c', 's', 'd', 'i'
+  def align(self, l1, l2):
+    # compute matrix
+    dp_matrix = [[0] * (len(l2) + 1) for _ in range((len(l1) + 1))]
+    for i in range(len(l1) + 1):
+      dp_matrix[i][0] = i * self.gapPenalty
+    for j in range(len(l2) + 1):
+      dp_matrix[0][j] = j * self.gapPenalty
+    for i in range(0, len(l1)):
+      for j in range(0, len(l2)):
+        match = dp_matrix[i][j] + self.sim(l1[i], l2[j])
+        delete = dp_matrix[i][j + 1] + self.gapPenalty
+        insert = dp_matrix[i + 1][j] + self.gapPenalty
+        dp_matrix[i + 1][j + 1] = max(match, delete, insert)
+    c = dp_matrix[len(l1)][len(l2)]
+    x = []
+    y = []
+    i = len(l1) - 1
+    j = len(l2) - 1
+    while i >= 0 and j >= 0:
+      score = dp_matrix[i + 1][j + 1]
+      score_diag = dp_matrix[i][j]
+      score_up = dp_matrix[i + 1][j]
+      score_left = dp_matrix[i][j + 1]
+      if score == score_left + self.gapPenalty:
+        x = [l1[i]] + x
+        y = [self.gapSymbol] + y
+        i -= 1
+      elif score == score_up + self.gapPenalty:
+        x = [self.gapSymbol] + x
+        y = [l2[j]] + y
+        j -= 1
+      else:
+        assert score == score_diag + self.sim(l1[i], l2[j])
+        x = [l1[i]] + x
+        y = [l2[j]] + y
+        i -= 1
+        j -= 1
+    while i >= 0:
+      x = [l1[i]] + x
+      y = [self.gapSymbol] + y
+      i -= 1
+    while j >= 0:
+      x = [self.gapSymbol] + x
+      y = [l2[j]] + y
+      j -= 1
+    s = []
+    assert len(x) == len(y)
+    for i in range(len(x)):
+      if x[i] is self.gapSymbol and y[i] is not self.gapSymbol:
+        s.append('i')
+      elif x[i] is not self.gapSymbol and y[i] is self.gapSymbol:
+        s.append('d')
+      elif self.sim(x[i], y[i]) >= 0:
+        s.append('c')
+      else:
+        s.append('s')
+    return c, x, y, s

--- a/xnmt/xnmt_evaluate.py
+++ b/xnmt/xnmt_evaluate.py
@@ -56,7 +56,7 @@ def xnmt_evaluate(ref_file: Union[str, Sequence[str]], hyp_file: Union[str, Sequ
     logger.info(f"> ignoring {len_before - len(ref_corpus)} out of {len_before} test sentences.")
 
   if is_multi:
-    return [evaluator.evaluate_multi(ref_corpus, hyp_corpus, desc=desc) for evaluator in evaluators]
+    return [evaluator.evaluate_multi_ref(ref_corpus, hyp_corpus, desc=desc) for evaluator in evaluators]
   else:
     return [evaluator.evaluate(ref_corpus, hyp_corpus, desc=desc) for evaluator in evaluators]
 


### PR DESCRIPTION
Refactors evaluators to support sentence-level evaluation. The main idea is to add a ```SentenceLevelEvaluator``` abstract class:
- subclass implement only ```eval_one_sent()``` to compute scores for a single sentence
- ```SentenceLevelEvaluator.evaluate()``` and ```SentenceLevelEvaluator.evaluate_multi_ref()``` take care of computing corpus-level scores. This uses the new ```SentenceLevelEvalScore.aggregate()``` method that must be implemented by the corresponding score classes.

Most classes (except the BLEU evaluators and ```ExternalEvaluator```) adhere to this new interface.

This comes with a few new features:
- ```SentenceLevelEvaluator``` subclasses support writing out of sentence-level scores to a YAML file.
- Multi-reference evaluation is now supported by most evaluators.
- WER/CER now print statistics about the number of correct/sub/ins/del.