### PR TITLE
SentenceFilterLength: fix min sentence length and max/min index

### DIFF
--- a/xnmt/preproc.py
+++ b/xnmt/preproc.py
@@ -273,7 +273,7 @@ class SentenceFilterer(object):
           raise RuntimeError("Unknown preprocessing type {}".format(my_spec["type"]))
     return preproc_list
 
-class SentenceFiltererLength(object):
+class SentenceFiltererLength(SentenceFilterer):
   """Filters sentences by length"""
 
   def __init__(self, spec):

--- a/xnmt/preproc.py
+++ b/xnmt/preproc.py
@@ -299,10 +299,10 @@ class SentenceFiltererLength(object):
         self.overall_min = v
       else:
         direc, idx = k.split('_')
-        idx = idx_map.get(idx_map, int(idx))
+        idx = idx_map.get(idx, int(idx))
         if direc == "max":
           self.each_max[idx] = v
-        elif direc == "max":
+        elif direc == "min":
           self.each_min[idx] = v
         else:
           raise RuntimeError("Unknown limitation type {} in length-based sentence filterer".format(k))

--- a/xnmt/preproc.py
+++ b/xnmt/preproc.py
@@ -299,7 +299,11 @@ class SentenceFiltererLength(object):
         self.overall_min = v
       else:
         direc, idx = k.split('_')
-        idx = idx_map.get(idx, int(idx))
+        idx_tmp = idx_map.get(idx)
+        if idx_tmp is None:
+          idx_tmp = int(idx)
+        idx = idx_tmp
+
         if direc == "max":
           self.each_max[idx] = v
         elif direc == "min":


### PR DESCRIPTION
For multiple min/ max values (min_0, ..) fixed the min assignment and the assignment in general.