### PR TITLE
fix dev loss word count is taken from the first dev task

### DIFF
--- a/xnmt/training_task.py
+++ b/xnmt/training_task.py
@@ -276,10 +276,13 @@ class SimpleTrainingTask(TrainingTask, Serializable):
     # Perform evaluation
     if self.dev_tasks and len(self.dev_tasks) > 0:
       dev_scores = []
+      dev_word_cnt = None
       with self.dev_loss_tracker.time_tracker:
         logger.info("> Checkpoint")
         for dev_task in self.dev_tasks:
-          dev_score, dev_word_cnt = dev_task.eval()
+          dev_score, tmp_word_cnt = dev_task.eval()
+          if dev_word_cnt is None:
+            dev_word_cnt = tmp_word_cnt
           if type(dev_score) == list:
             dev_scores.extend(dev_score)
           else:


### PR DESCRIPTION
The dev word count was previously taken from the last dev task, but the score from the frist task.
Now the word count is taken from the first task as well.