### PR TITLE
Preproc regex filter

### DIFF
--- a/xnmt/preproc.py
+++ b/xnmt/preproc.py
@@ -298,9 +298,9 @@ class SentenceFiltererMatchingRegex(SentenceFilterer):
     for i, sent in enumerate(sents):
       if type(sent) == list:
         sent = " ".join(sent)
-
-      if re.search(self.regex.get(i, ""), sent) is None:
-        return False
+      if self.regex.get(i) is not None:
+        if re.search(self.regex[i], sent) is None:
+          return False
     return True
 
 class SentenceFiltererLength(SentenceFilterer):

--- a/xnmt/preproc.py
+++ b/xnmt/preproc.py
@@ -277,8 +277,18 @@ class SentenceFilterer(object):
     return preproc_list
 
 class SentenceFiltererMatchingRegex(SentenceFilterer):
+  """Filters sentences via regular expressions.
+  A sentence must match the expression to be kept.
+  """
 
   def __init__(self, spec):
+    """Specifies the regular expressions to filter the sentences that we'll be getting.
+
+    The regular expressions are passed as a dictionary with keys as follows:
+      regex_INT: This will specify the regular expression for a specific language (zero indexed)
+      regex_src: Equivalent to regex_0
+      regex_trg: Equivalent to regex_1
+    """
     self.regex = {}
     idx_map = {"src": 0, "trg": 1}
     for k, v in spec.items():


### PR DESCRIPTION
Added a preprocessing filter that can filter sentences by regular expression.

Example usage:
```
    - !PreprocFilter
      in_files:
      - examples/data/head.ja
      - examples/data/head.en
      out_files:
      - examples/output/head.filter.ja
      - examples/output/head.filter.en
      specs:
      - type: matching-regex
        regex_trg: "you"
```