### PR TITLE
Fix max len

### DIFF
--- a/recipes/las-tedlium/config.las-pyramidal.yaml
+++ b/recipes/las-tedlium/config.las-pyramidal.yaml
@@ -73,8 +73,8 @@ las-pyramidal: !Experiment
         inference: !SimpleInference
           max_src_len: 1500
           post_process: join-char
-          max_len: 500
           search_strategy: !BeamSearch
+            max_len: 500
             beam_size: 20
             len_norm: !PolynomialNormalization
               apply_during_search: true
@@ -92,8 +92,8 @@ las-pyramidal: !Experiment
       inference: !SimpleInference
         max_src_len: 1500
         post_process: join-char
-        max_len: 500
         search_strategy: !BeamSearch
+          max_len: 500
           beam_size: 20
           len_norm: !PolynomialNormalization
             apply_during_search: true

--- a/xnmt/inference.py
+++ b/xnmt/inference.py
@@ -44,7 +44,7 @@ class SimpleInference(Serializable):
   def __init__(self, src_file: Optional[str] = None, trg_file: Optional[str] = None, ref_file: Optional[str] = None,
                max_src_len: Optional[int] = None, post_process: str = "none", report_path: Optional[str] = None,
                report_type: str = "html", search_strategy: SearchStrategy = bare(BeamSearch), mode: str = "onebest",
-               max_len: Optional[int] = None, batcher: Optional[Batcher] = Ref("train.batcher", default=None)):
+               batcher: Optional[Batcher] = Ref("train.batcher", default=None)):
     self.src_file = src_file
     self.trg_file = trg_file
     self.ref_file = ref_file
@@ -55,7 +55,6 @@ class SimpleInference(Serializable):
     self.mode = mode
     self.batcher = batcher
     self.search_strategy = search_strategy
-    self.max_len = max_len
 
   def __call__(self, generator: GeneratorModel, src_file: str = None, trg_file: str = None,
                candidate_id_file: str = None):
@@ -99,10 +98,6 @@ class SimpleInference(Serializable):
           ref_corpus.append(trg_input)
       if self.mode == "score":
         src_corpus = score_src_corpus
-      else:
-        if self.max_len and any(len(s) > self.max_len for s in ref_corpus):
-          logger.warning("Forced decoding with some targets being longer than max_len. "
-                         "Increase max_len to avoid unexpected behavior.")
     else:
       ref_corpus = None
     # Vocab

--- a/xnmt/search_strategy.py
+++ b/xnmt/search_strategy.py
@@ -5,6 +5,7 @@ import dynet as dy
 import numpy as np
 
 import xnmt.batcher
+from xnmt import logger
 from xnmt.length_normalization import NoNormalization
 from xnmt.persistence import Serializable, serializable_init, bare
 from xnmt.vocab import Vocab
@@ -123,6 +124,10 @@ class BeamSearch(Serializable, SearchStrategy):
   def generate_output(self, translator, initial_state, src_length=None, forced_trg_ids=None):
     # TODO(philip30): can only do single decoding, not batched
     assert forced_trg_ids is None or self.beam_size == 1
+    if forced_trg_ids and len(forced_trg_ids) > self.max_len:
+      logger.warning("Forced decoding with a target longer than max_len. "
+                     "Increase max_len to avoid unexpected behavior.")
+
     active_hyp = [self.Hypothesis(0, None, None, None)]
     completed_hyp = []
     for length in range(self.max_len):


### PR DESCRIPTION
A little while ago max-len was moved from ``SimpleInference`` to ``BeamSearch``, but the argument wasn't removed from ``SimpleInference``.