### PR TITLE
update_every

### DIFF
--- a/xnmt/mlp.py
+++ b/xnmt/mlp.py
@@ -44,7 +44,6 @@ class MLP(Serializable):
                vocab=None,
                trg_reader=Ref("model.trg_reader", default=None),
                decoder_rnn_dim=Ref("exp_global.default_layer_dim", default=None)):
-    model = ParamManager.my_params(self)
     self.input_dim = input_dim
     self.hidden_dim = hidden_dim
     self.output_dim = output_dim


### PR DESCRIPTION
This PR implements a new ```update_every``` option for all training regimens that simply skips the call to ```trainer.update()``` for an appropriate number of minibatches in case ```update_every > 1```. Also includes some improved type annotations for SimpleTrainingRegimen.