### PR TITLE
Optimization features

### DIFF
--- a/docs/save_file_format.rst
+++ b/docs/save_file_format.rst
@@ -1,4 +1,4 @@
-.. _sec-programming-style:
+.. _save-file-format:
 
 Save File Format
 ================

--- a/examples/12_multi_task.yaml
+++ b/examples/12_multi_task.yaml
@@ -11,12 +11,13 @@ exp1-multi_task: !Experiment
     default_layer_dim: 64
   train: !SameBatchMultiTaskTrainingRegimen
     trainer: !AdamTrainer {}
+    n_task_steps: [2,1]
     tasks:
     - !SimpleTrainingTask # first task is the main task: it will control early stopping, learning rate schedule, model checkpoints, ..
       name: first_task
       run_for_epochs: 6
       batcher: !SrcBatcher
-        batch_size: 6 # batch size is twice as big as for task 2, which will give task 1 more impact during training
+        batch_size: 6
       src_file: examples/data/head.ja
       trg_file: examples/data/head.en
       model: !DefaultTranslator
@@ -59,7 +60,7 @@ exp1-multi_task: !Experiment
     - !SimpleTrainingTask
       name: second_task
       batcher: !SrcBatcher
-        batch_size: 3
+        batch_size: 6
       src_file: examples/data/head.ja
       trg_file: examples/data/head.en
       model: !DefaultTranslator

--- a/xnmt/mlp.py
+++ b/xnmt/mlp.py
@@ -44,7 +44,6 @@ class MLP(Serializable):
                vocab=None,
                trg_reader=Ref("model.trg_reader", default=None),
                decoder_rnn_dim=Ref("exp_global.default_layer_dim", default=None)):
-    model = ParamManager.my_params(self)
     self.input_dim = input_dim
     self.hidden_dim = hidden_dim
     self.output_dim = output_dim

--- a/xnmt/util.py
+++ b/xnmt/util.py
@@ -1,6 +1,8 @@
 import os
-from typing import TypeVar, Sequence, Union, Dict,List
 import time
+import math
+
+import numpy as np
 
 from xnmt import logger, yaml_logger
 
@@ -20,3 +22,33 @@ def log_readable_and_structured(template, args, task_name=None):
   if task_name: args["task_name"] = task_name
   logger.info(template.format(**args), extra=args)
   yaml_logger.info(args)
+
+class RollingStatistic(object):
+  """
+  Efficient computation of rolling average and standard deviations.
+
+  Code adopted from http://jonisalonen.com/2014/efficient-and-accurate-rolling-standard-deviation/
+  """
+
+  def __init__(self, window_size=100):
+    self.N = window_size
+    self.average = None
+    self.variance = None
+    self.stddev = None
+    self.vals = []
+
+  def update(self, new):
+    self.vals.append(new)
+    if len(self.vals) == self.N:
+      self.average = np.average(self.vals)
+      self.variance = np.var(self.vals)
+      self.stddev = math.sqrt(self.variance)
+    elif len(self.vals) == self.N+1:
+      old = self.vals.pop(0)
+      oldavg = self.average
+      newavg = oldavg + (new - old) / self.N
+      self.average = newavg
+      self.variance += (new - old) * (new - newavg + old - oldavg) / (self.N - 1)
+      self.stddev = math.sqrt(self.variance)
+    else:
+      assert len(self.vals) < self.N


### PR DESCRIPTION
This replaces #413 and adds 3 features to the optimizers that can help stabilize training:
- ```update_every```: simulated large-batch training
- ```skip_noisy```: keep track of a moving average and a moving standard deviation of the log of the gradient norm values, and abort a step if the norm of the gradient exceeds four standard deviations of the moving average. Reference: https://arxiv.org/pdf/1804.09849.pdf

UPDATE: ```clip_norm``` is already the default DyNet behavior and is now removed from this PR.