### PR TITLE
Fix list item ref-sharing

### DIFF
--- a/test/config/component_sharing.yaml
+++ b/test/config/component_sharing.yaml
@@ -1,14 +1,3 @@
-# This illustrates component and parameter sharing.
-# There are 2 ways to achieve this:
-# - YAML's anchor system where '&' denotes a named anchor, '*' denotes a reference to an anchor.
-#   This essentially copies values or subcomponents from one place to another.
-#   It can be combined with the << operator that allows copying parts of a dictionary, but overwriting other parts.
-# - XNMT's !Ref object creates a reference, meaning both places will point to the exact same Python object,
-#   and that DyNet parameters will be shared.
-#   References can be made by path or by name, as illustrated below. The name refers to a _xnmt_id that can
-#   be set in any component and must be unique.
-#   Note that references do not work across experiments (e.g. we cannot refer to exp2.load from within exp1.pretrain)
-
 exp1.pretrain: !Experiment
   exp_global: !ExpGlobal
     default_layer_dim: 32
@@ -19,12 +8,15 @@ exp1.pretrain: !Experiment
       vocab: !Vocab {vocab_file: examples/data/head.en.vocab}
     src_embedder: !SimpleWordEmbedder
       emb_dim: 32
-    encoder: !BiLSTMSeqTransducer
-      layers: 1
+    encoder: !ModularSeqTransducer
+      modules:
+      - !BiLSTMSeqTransducer
+        _xnmt_id: shared_enc
+        layers: 1
+      - !Ref { name: shared_enc }
     attender: !MlpAttender {}
-    # reference-sharing between softmax projection and target embedder. This means both layers share DyNet parameters!
     trg_embedder: !DenseWordEmbedder
-      _xnmt_id: trg_emb # this id must be unique and is needed to create a reference-by-name below.
+      _xnmt_id: trg_emb
       emb_dim: 32
     decoder: !MlpSoftmaxDecoder
       rnn_layer: !UniLSTMSeqTransducer
@@ -32,9 +24,6 @@ exp1.pretrain: !Experiment
       bridge: !CopyBridge {}
       mlp_layer: !MLP
         output_projector: !Ref { name: trg_emb }
-        #                alternatively, the same could be achieved like this,
-        #                in which case model.trg_embedder._xnmt_id is not required:
-        #                !Ref { path: model.trg_embedder }
     inference: !SimpleInference {}
   train: !SimpleTrainingRegimen
     run_for_epochs: 2
@@ -42,13 +31,13 @@ exp1.pretrain: !Experiment
     trg_file: examples/data/head.en
     dev_tasks:
       - !LossEvalTask
-        src_file: &dev_src examples/data/head.ja  # value-sharing between train.training_corpus.dev_src and inference.src_file
-        ref_file: &dev_trg examples/data/head.en  # value-sharing between train.training_corpus.dev_trg and evaluate.ref_file
+        src_file: &dev_src examples/data/head.ja
+        ref_file: &dev_trg examples/data/head.en
   evaluate:
     - !AccuracyEvalTask
       eval_metrics: bleu,wer
-      src_file: *dev_src # Copy over the file path from the dev tasks using YAML anchors.
-      ref_file: *dev_trg # The same could also be done for more complex objects.
+      src_file: *dev_src
+      ref_file: *dev_trg
       hyp_file: test/tmp/{EXP}.test_hyp
 
 exp2.load: !LoadSerialized

--- a/xnmt/__init__.py
+++ b/xnmt/__init__.py
@@ -56,11 +56,6 @@ import xnmt.persistence
 resolved_serialize_params = {}
 
 def init_representer(dumper, obj):
-  # assert hasattr(obj, "resolved_serialize_params") or hasattr(obj, "serialize_params")
-  # if hasattr(obj, "resolved_serialize_params"):
-  #   serialize_params = obj.resolved_serialize_params
-  # else:
-  #   serialize_params = obj.serialize_params
   if len(resolved_serialize_params)==0:
     serialize_params = obj.serialize_params
   else:

--- a/xnmt/__init__.py
+++ b/xnmt/__init__.py
@@ -53,12 +53,18 @@ import xnmt.transformer
 import xnmt.translator
 import xnmt.persistence
 
+resolved_serialize_params = {}
+
 def init_representer(dumper, obj):
-  assert hasattr(obj, "resolved_serialize_params") or hasattr(obj, "serialize_params")
-  if hasattr(obj, "resolved_serialize_params"):
-    serialize_params = obj.resolved_serialize_params
-  else:
+  # assert hasattr(obj, "resolved_serialize_params") or hasattr(obj, "serialize_params")
+  # if hasattr(obj, "resolved_serialize_params"):
+  #   serialize_params = obj.resolved_serialize_params
+  # else:
+  #   serialize_params = obj.serialize_params
+  if len(resolved_serialize_params)==0:
     serialize_params = obj.serialize_params
+  else:
+    serialize_params = resolved_serialize_params[id(obj)]
   return dumper.represent_mapping('!' + obj.__class__.__name__, serialize_params)
 
 import yaml

--- a/xnmt/persistence.py
+++ b/xnmt/persistence.py
@@ -1254,6 +1254,14 @@ def _resolve_serialize_refs(root):
                 xnmt.resolved_serialize_params[id(ref)] = ref.serialize_params
                 # _set_descendant(root, path_from.parent().append("resolved_serialize_params").append(path_from[-1]), ref)
                 _set_descendant(xnmt.resolved_serialize_params[id(_get_descendant(root, path_from.parent()))], Path(path_from[-1]), ref)
+                if isinstance(_get_descendant(root, path_from.parent()), (collections.abc.MutableMapping, collections.abc.Sequence)):
+                  assert isinstance(_get_descendant(root, path_from.parent().parent()), Serializable), \
+                    "resolving references inside nested lists/dicts is not yet implemented"
+                  xnmt.resolved_serialize_params[id(_get_descendant(root, path_from.parent().parent()))][
+                    path_from[-2]] = xnmt.resolved_serialize_params[id(_get_descendant(root, path_from.parent()))]
+                  # _set_descendant(
+                  #   xnmt.resolved_serialize_params[id(_get_descendant(root, path_from.parent().parent()))][path_from[-2]],
+                  #   Path(path_from[-1]), ref)
                 refs_inserted_at.add(path_from)
                 refs_inserted_to.add(path_from)
 

--- a/xnmt/persistence.py
+++ b/xnmt/persistence.py
@@ -1230,7 +1230,6 @@ def _resolve_serialize_refs(root):
       if not hasattr(node, "serialize_params"):
         raise ValueError(f"Cannot serialize node that has no serialize_params attribute: {node}\n"
                          "Did you forget to wrap the __init__() in @serializable_init ?")
-      # node.resolved_serialize_params = node.serialize_params
       xnmt.resolved_serialize_params[id(node)] = node.serialize_params
     elif isinstance(node, collections.abc.MutableMapping):
       xnmt.resolved_serialize_params[id(node)] = dict(node)
@@ -1250,18 +1249,13 @@ def _resolve_serialize_refs(root):
           if not path_from in refs_inserted_to:
             if path_from!=path_to and matching_node is node:
                 ref = Ref(path=path_to)
-                # ref.resolved_serialize_params = ref.serialize_params
                 xnmt.resolved_serialize_params[id(ref)] = ref.serialize_params
-                # _set_descendant(root, path_from.parent().append("resolved_serialize_params").append(path_from[-1]), ref)
                 _set_descendant(xnmt.resolved_serialize_params[id(_get_descendant(root, path_from.parent()))], Path(path_from[-1]), ref)
                 if isinstance(_get_descendant(root, path_from.parent()), (collections.abc.MutableMapping, collections.abc.Sequence)):
                   assert isinstance(_get_descendant(root, path_from.parent().parent()), Serializable), \
                     "resolving references inside nested lists/dicts is not yet implemented"
                   xnmt.resolved_serialize_params[id(_get_descendant(root, path_from.parent().parent()))][
                     path_from[-2]] = xnmt.resolved_serialize_params[id(_get_descendant(root, path_from.parent()))]
-                  # _set_descendant(
-                  #   xnmt.resolved_serialize_params[id(_get_descendant(root, path_from.parent().parent()))][path_from[-2]],
-                  #   Path(path_from[-1]), ref)
                 refs_inserted_at.add(path_from)
                 refs_inserted_to.add(path_from)
 


### PR DESCRIPTION
This fixes a problem that prevented reference-sharing of components that are list / dictionary items (e.g. sharing individual modules of the modular seq transducer).