### PR TITLE
Unicode tokenizer

### DIFF
--- a/examples/05_preproc.yaml
+++ b/examples/05_preproc.yaml
@@ -4,13 +4,8 @@ preproc: !Experiment
   exp_global: !ExpGlobal
     # define some named strings that can be used throughout the experiment config:
     placeholders:
-      # Specify <SENTENCEPIECE_SRC_PATH> with src/ directory of sentencepiece repository
-      # The spm_* executables should be located at <SENTENCEPIECE_SRC_PATH>
-      SENTENCEPIECE_SRC_PATH: ''
-
       DATA_IN: examples/data/
       DATA_OUT: examples/preproc/
-
   preproc: !PreprocRunner
     overwrite: False
     tasks:
@@ -32,16 +27,18 @@ preproc: !Experiment
       specs:
       - filenum: all
         tokenizers:
-        - !SentencepieceTokenizer
-          # Replace <SENTENCEPIECE_SRC_PATH> with src/ directory of sentencepiece repository
-          # The spm_* executables should be located at <SENTENCEPIECE_SRC_PATH>
-          path: <SENTENCEPIECE_SRC_PATH>
-          train_files:
-           - '{DATA_IN}/train.ja'
-           - '{DATA_IN}/train.en'
-          vocab_size: 8000
-          model_type: unigram
-          model_prefix: '{DATA_OUT}/sentpiece'
+        - !UnicodeTokenizer {}
+        # uncomment if you have installed the corresponding third-party tool:
+#        - !SentencepieceTokenizer
+#          # Replace <SENTENCEPIECE_SRC_PATH> with src/ directory of sentencepiece repository
+#          # The spm_* executables should be located at <SENTENCEPIECE_SRC_PATH>
+#          path: <SENTENCEPIECE_SRC_PATH>
+#          train_files:
+#           - '{DATA_IN}/train.ja'
+#           - '{DATA_IN}/train.en'
+#          vocab_size: 8000
+#          model_type: unigram
+#          model_prefix: '{DATA_OUT}/sentpiece'
     - !PreprocNormalize
       in_files:
       - '{DATA_OUT}/train.tok.ja'
@@ -63,8 +60,8 @@ preproc: !Experiment
       - '{DATA_OUT}/test.norm.en'
       specs:
       - filenum: all
-        spec:
-        - type: lower
+        normalizers:
+        - !NormalizerLower {}
     - !PreprocFilter
       in_files:
       - '{DATA_OUT}/train.tok.norm.ja'
@@ -85,9 +82,9 @@ preproc: !Experiment
       - '{DATA_OUT}/train.vocab.en'
       specs:
       - filenum: all
-        spec:
-        - type: freq
-          min_freq: 2
+        filters:
+        - !VocabFiltererFreq
+            min_freq: 2
   model: !DefaultTranslator
     src_reader: !PlainTextReader
       vocab: !Vocab
@@ -111,7 +108,7 @@ preproc: !Experiment
       mlp_layer: !MLP
         hidden_dim: 512
       bridge: !NoBridge {}
-    inference: !SimpleInference
+    inference: !SequenceInference
       post_process: join-piece
   train: !SimpleTrainingRegimen
     run_for_epochs: 20

--- a/examples/05_preproc.yaml
+++ b/examples/05_preproc.yaml
@@ -108,7 +108,7 @@ preproc: !Experiment
       mlp_layer: !MLP
         hidden_dim: 512
       bridge: !NoBridge {}
-    inference: !SequenceInference
+    inference: !SimpleInference
       post_process: join-piece
   train: !SimpleTrainingRegimen
     run_for_epochs: 20

--- a/examples/05_preproc.yaml
+++ b/examples/05_preproc.yaml
@@ -28,17 +28,6 @@ preproc: !Experiment
       - filenum: all
         tokenizers:
         - !UnicodeTokenizer {}
-        # uncomment if you have installed the corresponding third-party tool:
-#        - !SentencepieceTokenizer
-#          # Replace <SENTENCEPIECE_SRC_PATH> with src/ directory of sentencepiece repository
-#          # The spm_* executables should be located at <SENTENCEPIECE_SRC_PATH>
-#          path: <SENTENCEPIECE_SRC_PATH>
-#          train_files:
-#           - '{DATA_IN}/train.ja'
-#           - '{DATA_IN}/train.en'
-#          vocab_size: 8000
-#          model_type: unigram
-#          model_prefix: '{DATA_OUT}/sentpiece'
     - !PreprocNormalize
       in_files:
       - '{DATA_OUT}/train.tok.ja'

--- a/test/config/preproc.yaml
+++ b/test/config/preproc.yaml
@@ -24,8 +24,8 @@ standard-preproc: !Experiment
       - test/tmp/head.norm.en
       specs:
       - filenum: all
-        spec:
-        - type: lower
+        normalizers:
+        - !NormalizerLower {}
     - !PreprocFilter
       in_files:
       - test/tmp/head.tok.norm.ja
@@ -46,9 +46,9 @@ standard-preproc: !Experiment
       - test/tmp/head.vocab.en
       specs:
       - filenum: all
-        spec:
-        - type: freq
-          min_freq: 2
+        filters:
+        - !VocabFiltererFreq
+            min_freq: 2
   model: !DefaultTranslator
     src_reader: !PlainTextReader
       vocab: !Vocab
@@ -72,7 +72,7 @@ standard-preproc: !Experiment
       mlp_layer: !MLP
         hidden_dim: 256
       bridge: !NoBridge {}
-    inference: !SimpleInference
+    inference: !SequenceInference
       post_process: join-char
   train: !SimpleTrainingRegimen
     run_for_epochs: 2

--- a/test/config/preproc.yaml
+++ b/test/config/preproc.yaml
@@ -72,7 +72,7 @@ standard-preproc: !Experiment
       mlp_layer: !MLP
         hidden_dim: 256
       bridge: !NoBridge {}
-    inference: !SequenceInference
+    inference: !SimpleInference
       post_process: join-char
   train: !SimpleTrainingRegimen
     run_for_epochs: 2

--- a/xnmt/preproc.py
+++ b/xnmt/preproc.py
@@ -118,7 +118,10 @@ class CharacterTokenizer(Tokenizer, Serializable):
 
 class UnicodeTokenizer(Tokenizer, Serializable):
   """
-  Reversible, language-agnostic tokenizer based on unicode character categories.
+  Tokenizer that inserts whitespace between words and punctuation.
+
+  This tokenizer is language-agnostic and (optionally) reversible, and is based on unicode character categories.
+  See appendix of https://arxiv.org/pdf/1804.08205
 
   Args:
     use_merge_symbol: whether to prepend a merge-symbol so that the tokenization becomes reversible

--- a/xnmt/preproc.py
+++ b/xnmt/preproc.py
@@ -23,40 +23,32 @@ from xnmt.util import make_parent_dir
 class Normalizer(object):
   """A type of normalization to perform to a file. It is initialized first, then expanded."""
 
-  def __init__(self, spec=None):
-    """Initialize the normalizer from a specification."""
-    pass
-
   def normalize(self, sent):
     """Takes a plain text string and converts it into another plain text string after preprocessing."""
     raise RuntimeError("Subclasses of Normalizer must implement the normalize() function")
 
-  @staticmethod
-  def from_spec(spec):
-    """Takes a list of normalizer specifications, and returns the appropriate processors."""
-    preproc_list = []
-    if spec is not None:
-      for my_spec in spec:
-        if my_spec["type"] == "lower":
-          preproc_list.append(NormalizerLower(my_spec))
-        elif my_spec["type"] == "remove_punct":
-          preproc_list.append(NormalizerRemovePunct(my_spec))
-        else:
-          raise RuntimeError("Unknown normalizer type {}".format(my_spec["type"]))
-    return preproc_list
-
-class NormalizerLower(Normalizer):
+class NormalizerLower(Normalizer, Serializable):
   """Lowercase the text."""
+
+  yaml_tag = "!NormalizerLower"
 
   def normalize(self, sent):
     return sent.lower()
 
-class NormalizerRemovePunct(Normalizer):
-  """Remove punctuation from the text."""
-  def __init__(self, spec=None):
-    self.remove_inside_word = spec.get("remove_inside_word", False)
+class NormalizerRemovePunct(Normalizer, Serializable):
+  """Remove punctuation from the text.
+
+  Args:
+    remove_inside_word: If ``False``, only remove punctuation appearing adjacent to white space.
+    allowed_chars: Specify punctuation that is allowed and should not be removed.
+  """
+  yaml_tag = "!NormalizerRemovePunct"
+
+  @serializable_init
+  def __init__(self, remove_inside_word:bool=False, allowed_chars:str="") -> None:
+    self.remove_inside_word = remove_inside_word
     self.exclude = set(chr(i) for i in range(sys.maxunicode) if unicodedata.category(chr(i)).startswith('P')
-                                                              and chr(i) not in set(spec.get("allowed_chars", "")))
+                                                              and chr(i) not in set(allowed_chars))
   def normalize(self, sent):
     if self.remove_inside_word:
       ret = ''.join(ch for ch in sent if ch not in self.exclude)
@@ -123,6 +115,68 @@ class CharacterTokenizer(Tokenizer, Serializable):
   def tokenize(self, sent):
     """Tokenizes a single sentence into characters."""
     return ' '.join([('__' if x == ' ' else x) for x in sent])
+
+class UnicodeTokenizer(Tokenizer, Serializable):
+  """
+  Reversible, language-agnostic tokenizer based on unicode character categories.
+
+  Args:
+    use_merge_symbol: whether to prepend a merge-symbol so that the tokenization becomes reversible
+    merge_symbol: the merge symbol to use
+    reverse: whether to reverse tokenization (assumes use_merge_symbol=True was used in forward direction)
+  """
+  yaml_tag = '!UnicodeTokenizer'
+
+  @serializable_init
+  def __init__(self, use_merge_symbol: bool = True, merge_symbol: str = '↹', reverse: bool = False):
+    self.merge_symbol = merge_symbol if use_merge_symbol else ''
+    self.reverse = reverse
+
+  def tokenize(self, sent: str) -> str:
+    """Tokenizes a single sentence.
+
+    Args:
+      sent: input sentence
+    Returns:
+      output sentence
+    """
+    str_list = []
+    if not self.reverse:
+      for i in range(len(sent)):
+        c = sent[i]
+        c_p = sent[i - 1] if i > 0 else c
+        c_n = sent[i + 1] if i < len(sent) - 1 else c
+
+        if not UnicodeTokenizer._is_weird(c):
+          str_list.append(c)
+        else:
+          if not c_p.isspace():
+            str_list.append(' ' + self.merge_symbol)
+            str_list.append(c)
+          if not c_n.isspace() and not UnicodeTokenizer._is_weird(c_n):
+            str_list.append(self.merge_symbol + ' ')
+    else: # self.reverse==True
+      i = 0
+      while i < len(sent):
+        c = sent[i]
+        c_n = sent[i + 1] if i < len(sent) - 1 else c
+        c_nn = sent[i + 2] if i < len(sent) - 2 else c
+
+        if c + c_n == ' ' + self.merge_symbol and UnicodeTokenizer._is_weird(c_nn):
+          i += 2
+        elif UnicodeTokenizer._is_weird(c) and c_n + c_nn == self.merge_symbol + ' ':
+          str_list.append(c)
+          i += 3
+        else:
+          str_list.append(c)
+          i += 1
+    return ''.join(str_list)
+
+  @staticmethod
+  def _is_weird(c):
+    return not (unicodedata.category(c)[0] == 'L'
+                or unicodedata.category(c)[0] == 'N'
+                or c.isspace())
 
 class ExternalTokenizer(Tokenizer, Serializable):
   """
@@ -280,7 +334,6 @@ class SentenceFiltererMatchingRegex(SentenceFilterer):
   """Filters sentences via regular expressions.
   A sentence must match the expression to be kept.
   """
-
   def __init__(self, spec):
     """Specifies the regular expressions to filter the sentences that we'll be getting.
 
@@ -395,22 +448,24 @@ class VocabFilterer(object):
           raise RuntimeError("Unknown VocabFilterer type {}".format(my_spec["type"]))
     return preproc_list
 
-class VocabFiltererFreq(VocabFilterer):
+class VocabFiltererFreq(VocabFilterer, Serializable):
   """Filter the vocabulary, removing words below a particular minimum frequency"""
-
-  def __init__(self, spec):
+  yaml_tag = "!VocabFiltererFreq"
+  @serializable_init
+  def __init__(self, min_freq):
     """Specification contains a single value min_freq"""
-    self.min_freq = spec["min_freq"]
+    self.min_freq = min_freq
 
   def filter(self, vocab):
     return {k: v for k, v in vocab.items() if v >= self.min_freq}
 
-class VocabFiltererRank(VocabFilterer):
+class VocabFiltererRank(VocabFilterer, Serializable):
   """Filter the vocabulary, removing words above a particular frequency rank"""
-
-  def __init__(self, spec):
+  yaml_tag = "!VocabFiltererRank"
+  @serializable_init
+  def __init__(self, max_rank):
     """Specification contains a single value max_rank"""
-    self.max_rank = spec["max_rank"]
+    self.max_rank = max_rank
 
   def filter(self, vocab):
     if len(vocab) <= self.max_rank:
@@ -428,9 +483,10 @@ class Extractor(object):
 class MelFiltExtractor(Extractor, Serializable):
   yaml_tag = "!MelFiltExtractor"
   @serializable_init
-  def __init__(self, nfilt=40, delta=False):
+  def __init__(self, nfilt=40, delta=False, resume=False):
     self.delta = delta
     self.nfilt = nfilt
+    self.resume = resume
   def extract_to(self, in_file, out_file):
     """
     in_file: yaml file that contains a list of dictionaries.
@@ -447,7 +503,7 @@ class MelFiltExtractor(Extractor, Serializable):
     if not out_file.endswith(".h5"): raise ValueError(f"out_file must end in '.h5', was '{out_file}'")
     start_time = time.time()
     with open(in_file) as in_stream, \
-         h5py.File(out_file, "w") as hf:
+         h5py.File(out_file, "r+" if self.resume else "w") as hf:
       db = yaml.load(in_stream)
       db_by_speaker = defaultdict(list)
       for db_index, db_item in enumerate(db):
@@ -455,10 +511,19 @@ class MelFiltExtractor(Extractor, Serializable):
         db_item["index"] = db_index
         db_by_speaker[speaker_id].append(db_item)
       for speaker_id in db_by_speaker.keys():
+        speaker_already_completed = True
+        for db_item in db_by_speaker[speaker_id]:
+          if str(db_item["index"]) not in hf.keys():
+            speaker_already_completed = False
+            break
+        if self.resume and speaker_already_completed:
+          logger.debug(f"{speaker_id} already done")
+          continue
         data = []
         for db_item in db_by_speaker[speaker_id]:
-          y, sr = librosa.load(db_item["wav"], sr=16000, 
-                               offset=db_item.get("offset", 0.0), 
+          logger.debug(f"processing db_item {db_item}")
+          y, sr = librosa.load(db_item["wav"], sr=16000,
+                               offset=db_item.get("offset", 0.0),
                                duration=db_item.get("duration", None))
           if len(y)==0: raise ValueError(f"encountered an empty or out of bounds segment: {db_item}")
           logmel = logfbank(y, samplerate=sr, nfilt=self.nfilt)

--- a/xnmt/preproc_runner.py
+++ b/xnmt/preproc_runner.py
@@ -37,6 +37,9 @@ class PreprocRunner(Serializable):
 
       task.run_preproc_task(overwrite = overwrite)
 
+class PreprocTask(object):
+  def run_preproc_task(self, overwrite=False):
+    ...
 
 class PreprocExtract(PreprocTask, Serializable):
   yaml_tag = "!PreprocExtract"
@@ -82,7 +85,9 @@ class PreprocNormalize(PreprocTask, Serializable):
     self.out_files = out_files
     self.specs = specs
   def run_preproc_task(self, overwrite=False):
-    normalizers = {my_opts["filenum"]: Normalizer.from_spec(my_opts["spec"]) for my_opts in self.specs}
+    normalizers = {my_opts["filenum"]: [norm
+          for norm in my_opts["normalizers"]]
+          for my_opts in self.specs}
     for i, (in_file, out_file) in enumerate(zip(self.in_files, self.out_files)):
       if overwrite or not os.path.isfile(out_file):
         make_parent_dir(out_file)
@@ -120,6 +125,7 @@ class PreprocFilter(PreprocTask, Serializable):
       if x is not None:
         x.close()
 
+
 class PreprocVocab(PreprocTask, Serializable):
   yaml_tag = "!PreprocVocab"
   @serializable_init
@@ -128,7 +134,9 @@ class PreprocVocab(PreprocTask, Serializable):
     self.out_files = out_files
     self.specs = specs
   def run_preproc_task(self, overwrite=False):
-    filters = {my_opts["filenum"]: VocabFilterer.from_spec(my_opts["spec"]) for my_opts in self.specs}
+    filters = {my_opts["filenum"]: [norm
+          for norm in my_opts["filters"]]
+          for my_opts in self.specs}
     for i, (in_file, out_file) in enumerate(zip(self.in_files, self.out_files)):
       if overwrite or not os.path.isfile(out_file):
         make_parent_dir(out_file)


### PR DESCRIPTION
Implements the reversible, language-independent tokenizer from the appendix of https://arxiv.org/pdf/1804.08205

While at it, I also made some places a bit more YAML-like. I did not change the filterers because their initializer arguments are a bit more complicated and might require **kwargs syntax which currently is not supported by the XNMT serializer (although it would be nice to have..).