### PR TITLE
Made train/test time behavior of input readers different

### DIFF
--- a/examples/20_subword_sample.yaml
+++ b/examples/20_subword_sample.yaml
@@ -1,20 +1,25 @@
 # Sampling subword units for subword regularization 
 subword_sample: !Experiment 
-  # global parameters shared throughout the experiment
   exp_global: !ExpGlobal
-    # {EXP_DIR} is a placeholder for the directory in which the config file lies.
-    # {EXP} is a placeholder for the experiment name (here: 'standard')
     model_file: '{EXP_DIR}/models/{EXP}.mod'
     log_file: '{EXP_DIR}/logs/{EXP}.log'
     default_layer_dim: 512
     dropout: 0.3
-  # model architecture
   model: !DefaultTranslator
-    src_reader: !SubwordSampleTextReader
-      vocab: !Vocab {vocab_file: examples/data/head.ja.vocab}
+    # Here we set the sample_train and alpha parameters to turn on sampling
+    src_reader: !SentencePieceTextReader
+      sample_train: True
+      alpha: 0.1
+      vocab: !Vocab
+        vocab_file: examples/data/big-ja.vocab
+        sentencepiece_vocab: True
       model_file: examples/data/big-ja.model
-    trg_reader: !SubwordSampleTextReader
-      vocab: !Vocab {vocab_file: examples/data/head.en.vocab}
+    trg_reader: !SentencePieceTextReader
+      sample_train: True
+      alpha: 0.1
+      vocab: !Vocab
+        vocab_file: examples/data/big-en.vocab
+        sentencepiece_vocab: True
       model_file: examples/data/big-en.model
     src_embedder: !SimpleWordEmbedder
       emb_dim: 512
@@ -33,13 +38,15 @@ subword_sample: !Experiment
         hidden_dim: 512
         activation: 'tanh'
       bridge: !CopyBridge {}
+    inference: !SimpleInference
+      post_process: join-piece
   # training parameters
   train: !SimpleTrainingRegimen
     batcher: !SrcBatcher
       batch_size: 32
     trainer: !AdamTrainer
       alpha: 0.001
-    run_for_epochs: 2
+    run_for_epochs: 20
     src_file: examples/data/head.ja
     trg_file: examples/data/head.en
     dev_tasks:

--- a/xnmt/input_reader.py
+++ b/xnmt/input_reader.py
@@ -139,10 +139,19 @@ class SentencePieceTextReader(BaseTextReader, Serializable):
   yaml_tag = '!SentencePieceTextReader'
 
   @serializable_init
-  def __init__(self, model_file, sample=False, l=-1, alpha=0.1, vocab=None, include_vocab_reference=False):
+  def __init__(self, model_file, sample_train=False, l=-1, alpha=0.1, vocab=None, include_vocab_reference=False):
+    """
+    Args:
+      model_file: The sentence piece model file
+      sample_train: On the training set, sample outputs
+      l: The "l" parameter for subword regularization, how many sentences to sample
+      alpha: The "alpha" parameter for subowrd regularization, how much to smooth the distribution
+      vocab: The vocabulary
+      include_vocab_reference: Whether to include the vocab with the input
+    """
     self.subword_model = spm.SentencePieceProcessor()
     self.subword_model.Load(model_file)
-    self.sample = sample
+    self.sample_train = sample_train
     self.l = l
     self.alpha = alpha
     self.vocab = vocab
@@ -154,10 +163,10 @@ class SentencePieceTextReader(BaseTextReader, Serializable):
 
   def read_sent(self, sentence, filter_ids=None):
     vocab_reference = self.vocab if self.include_vocab_reference else None
-    if self.sample and self.train:
-      words = self.subword_model.SampleEncode(sentence.strip(), self.l, self.alpha)
+    if self.sample_train and self.train:
+      words = self.subword_model.SampleEncodeAsPieces(sentence.strip(), self.l, self.alpha)
     else:
-      words = self.subword_model.Encode(sentence.strip())
+      words = self.subword_model.EncodeAsPieces(sentence.strip())
     return SimpleSentenceInput([self.vocab.convert(word) for word in words] + \
                                                        [self.vocab.convert(Vocab.ES_STR)], vocab_reference)
 

--- a/xnmt/training_task.py
+++ b/xnmt/training_task.py
@@ -160,12 +160,14 @@ class SimpleTrainingTask(TrainingTask, Serializable):
       if self.training_state.epoch_num > 0:
         logger.info('using reloaded data')
       # reload the data   
+      self.model.src_reader.train = self.model.trg_reader.train = True
       self.src_data, self.trg_data, self.src_batches, self.trg_batches = \
           input_reader.read_parallel_corpus(self.model.src_reader, self.model.trg_reader,
                                           self.src_file, self.trg_file,
                                           batcher=self.batcher, sample_sents=self.sample_train_sents,
                                           max_num_sents=self.max_num_train_sents,
                                           max_src_len=self.max_src_len, max_trg_len=self.max_trg_len)
+      self.model.src_reader.train = self.model.trg_reader.train = False
       # restart data generation
       self._augmentation_handle = Popen(augment_command + " --epoch %d" % self.training_state.epoch_num, shell=True)
     else:
@@ -215,12 +217,14 @@ class SimpleTrainingTask(TrainingTask, Serializable):
         self._augment_data_next_epoch()
     if self.training_state.epoch_num==0 or self.sample_train_sents or \
       self.model.src_reader.needs_reload() or self.model.trg_reader.needs_reload():
+      self.model.src_reader.train = self.model.trg_reader.train = True
       self.src_data, self.trg_data, self.src_batches, self.trg_batches = \
         input_reader.read_parallel_corpus(self.model.src_reader, self.model.trg_reader,
                                                self.src_file, self.trg_file,
                                                batcher=self.batcher, sample_sents=self.sample_train_sents,
                                                max_num_sents=self.max_num_train_sents,
                                                max_src_len=self.max_src_len, max_trg_len=self.max_trg_len)
+      self.model.src_reader.train = self.model.trg_reader.train = False
     self.training_state.epoch_seed = random.randint(1,2147483647)
     random.seed(self.training_state.epoch_seed)
     np.random.seed(self.training_state.epoch_seed)


### PR DESCRIPTION
This makes it possible to moderate the train/test time behavior of InputReaders differently, and shows an example with sampling from a SentencePiece model:
https://github.com/neulab/xnmt/issues/430

There are some other changes:
* SentencePieceInputReader can now be used without sampling at all, if you want to just apply a model before-hand.
* Several bugs in the example configuration for subword regularization are fixed (added "join-pieces", made vocab reading correct, etc.)
* SentencePiece functions are switched to "EncodeAsPieces".