### PR TITLE
Fix unicode tokenizer

### DIFF
--- a/xnmt/preproc.py
+++ b/xnmt/preproc.py
@@ -177,9 +177,7 @@ class UnicodeTokenizer(Tokenizer, Serializable):
 
   @staticmethod
   def _is_weird(c):
-    return not (unicodedata.category(c)[0] == 'L'
-                or unicodedata.category(c)[0] == 'N'
-                or c.isspace())
+    return not (unicodedata.category(c)[0] in 'LMN' or c.isspace())
 
 class ExternalTokenizer(Tokenizer, Serializable):
   """


### PR DESCRIPTION
The Unicode tokenizer had a problem with splitting Unicode diacritics as punctuation:
> http://unicode.org/faq/char_combmark.html

These should not be segmented, so this PR fixes this.