### PR TITLE
Better computation time tracking for same-batch multi tasking

### DIFF
--- a/test/test_training.py
+++ b/test/test_training.py
@@ -13,7 +13,7 @@ import xnmt.events
 from xnmt.input_reader import PlainTextReader
 from xnmt.lstm import UniLSTMSeqTransducer, BiLSTMSeqTransducer
 from xnmt.loss_calculator import AutoRegressiveMLELoss
-from xnmt.optimizer import AdamTrainer
+from xnmt.optimizer import AdamTrainer, DummyTrainer
 from xnmt.param_collection import ParamManager
 from xnmt.pyramidal import PyramidalLSTMSeqTransducer
 import xnmt.training_regimen
@@ -302,11 +302,11 @@ class TestTrainDevLoss(unittest.TestCase):
                                             src_file="examples/data/head.ja",
                                             ref_file="examples/data/head.en",
                                             batcher=batcher)]
-    train_args['trainer'] = None
+    train_args['trainer'] = DummyTrainer()
     train_args['batcher'] = batcher
     train_args['run_for_epochs'] = 1
     training_regimen = xnmt.training_regimen.SimpleTrainingRegimen(**train_args)
-    training_regimen.run_training(save_fct = lambda: None, update_weights=False)
+    training_regimen.run_training(save_fct = lambda: None)
     self.assertAlmostEqual(training_regimen.train_loss_tracker.epoch_loss.sum_factors() / training_regimen.train_loss_tracker.epoch_words,
                            training_regimen.dev_loss_tracker.dev_score.loss, places=5)
 
@@ -351,7 +351,7 @@ class TestOverfitting(unittest.TestCase):
     train_args['batcher'] = batcher
     training_regimen = xnmt.training_regimen.SimpleTrainingRegimen(**train_args)
     for _ in range(50):
-      training_regimen.run_training(save_fct=lambda:None, update_weights=True)
+      training_regimen.run_training(save_fct=lambda:None)
     self.assertAlmostEqual(0.0,
                            training_regimen.train_loss_tracker.epoch_loss.sum_factors() / training_regimen.train_loss_tracker.epoch_words,
                            places=2)

--- a/xnmt/loss_tracker.py
+++ b/xnmt/loss_tracker.py
@@ -24,7 +24,7 @@ class AccumTimeTracker(object):
 class TrainLossTracker(object):
 
   REPORT_TEMPLATE_SPEED = 'Epoch {epoch:.4f}: {data}_loss/word={loss:.6f} (words={words}, words/sec={words_per_sec:.2f}, time={time})'
-  REPORT_TEMPLATE = 'Epoch {epoch:.4f}: {data}_loss/word={loss:.6f} (words={words}, time={time})'
+  REPORT_TEMPLATE = 'Epoch {epoch:.4f}: {data}_loss/word={loss:.6f} (words={words}, words/sec={words_per_sec}, time={time})'
   REPORT_TEMPLATE_ADDITIONAL = '- {loss_name} {loss:5.6f}'
   REPORT_EVERY = 1000
 

--- a/xnmt/optimizer.py
+++ b/xnmt/optimizer.py
@@ -77,10 +77,10 @@ class XnmtOptimizer(object):
 
   @property
   def learning_rate(self):
-      return self.optimizer.learning_rate
+    return self.optimizer.learning_rate
   @learning_rate.setter
   def learning_rate(self, value):
-      self.optimizer.learning_rate = value
+    self.optimizer.learning_rate = value
 
   def _check_gradients_noisy(self) -> bool:
     sq_norm = 0
@@ -238,3 +238,37 @@ class TransformerAdamTrainer(XnmtOptimizer, Serializable):
     if self.steps % 200 == 0:
       logger.info('> Optimizer Logging')
       logger.info('  Steps=%d, learning_rate=%.2e' % (self.steps, self.optimizer.learning_rate))
+
+
+
+class DummyTrainer(XnmtOptimizer, Serializable):
+  """
+  A dummy trainer that does not perform any parameter updates.
+  """
+  yaml_tag = "!DummyTrainer"
+
+  @serializable_init
+  def __init__(self):
+    pass
+
+  def update(self) -> None:
+    pass
+
+  def status(self):
+    return "n/a"
+
+  def set_clip_threshold(self, thr):
+    pass
+
+  def get_clip_threshold(self):
+    pass
+
+  def restart(self):
+    pass
+
+  @property
+  def learning_rate(self):
+    return 1.0
+  @learning_rate.setter
+  def learning_rate(self, value):
+    pass

--- a/xnmt/training_regimen.py
+++ b/xnmt/training_regimen.py
@@ -288,7 +288,6 @@ class SameBatchMultiTaskTrainingRegimen(MultiTaskTrainingRegimen, Serializable):
         with contextlib.ExitStack() as stack: #use exit stack to control whether to use global or per-task time tracking
           if not self.per_task_backward:
             stack.enter_context(self.train_loss_trackers[self.tasks[0]].time_tracker)
-        # with self.train_loss_trackers[self.tasks[0]].time_tracker:
           self.trigger_train_event(True)
           for task, src, trg in task_src_trg:
             with contextlib.ExitStack() as stack2:

--- a/xnmt/training_regimen.py
+++ b/xnmt/training_regimen.py
@@ -17,13 +17,12 @@ class TrainingRegimen(object):
   """
   A training regimen is a class that implements a training loop.
   """
-  def run_training(self, save_fct, update_weights=True):
+  def run_training(self, save_fct):
     """
     Run training steps in a loop until stopping criterion is reached.
 
     Args:
       save_fct: function to be invoked to save a model at dev checkpoints
-      update_weights (bool): Whether parameters should be updated
     """
     raise NotImplementedError("")
 
@@ -130,7 +129,7 @@ class SimpleTrainingRegimen(training_task.SimpleTrainingTask, TrainingRegimen, S
     self.update_every = update_every
     self.num_updates_skipped = 0
 
-  def run_training(self, save_fct, update_weights=True):
+  def run_training(self, save_fct):
     """
     Main training loop (overwrites TrainingRegimen.run_training())
     """
@@ -145,9 +144,8 @@ class SimpleTrainingRegimen(training_task.SimpleTrainingTask, TrainingRegimen, S
             self.model.set_train(True)
             loss_builder = self.training_step(src, trg)
             loss = loss_builder.compute()
-            if update_weights:
-              self.backward(loss, self.dynet_profiling)
-              self.update(self.trainer)
+            self.backward(loss, self.dynet_profiling)
+            self.update(self.trainer)
           self.train_loss_tracker.report(trg, loss_builder.get_factored_loss_val(comb_method=self.loss_comb_method))
         if self.checkpoint_needed():
           self.checkpoint_and_save(save_fct)
@@ -271,7 +269,7 @@ class SameBatchMultiTaskTrainingRegimen(MultiTaskTrainingRegimen, Serializable):
     if len(self.n_task_steps) != len(tasks):
       raise ValueError(f"number of tasks and steps per task do not match: {len(tasks)} != {len(self.n_task_steps)}")
 
-  def run_training(self, save_fct, update_weights=True):
+  def run_training(self, save_fct):
     task_generators = OrderedDict()
     for task in self.tasks:
       task_generators[task] = task.next_minibatch()
@@ -303,10 +301,9 @@ class SameBatchMultiTaskTrainingRegimen(MultiTaskTrainingRegimen, Serializable):
                 dy.renew_cg(immediate_compute=settings.IMMEDIATE_COMPUTE, check_validity=settings.CHECK_VALIDITY)
               else:
                 task_losses.append(loss_builder.compute())
-          if update_weights:
-            if not self.per_task_backward:
-              self.backward(sum(task_losses), self.dynet_profiling)
-            self.update(self.trainer)
+          if not self.per_task_backward:
+            self.backward(sum(task_losses), self.dynet_profiling)
+          self.update(self.trainer)
         for task, (trg, stats) in task_trg_loss_stats.items():
           self.train_loss_trackers[task].report(trg, stats)
         self.checkpoint_and_save(save_fct)
@@ -366,7 +363,7 @@ class AlternatingBatchMultiTaskTrainingRegimen(MultiTaskTrainingRegimen, Seriali
     self.train_loss_trackers = {task: TrainLossTracker(task) for task in tasks}
     self.loss_comb_method = loss_comb_method
 
-  def run_training(self, save_fct, update_weights=True):
+  def run_training(self, save_fct):
     task_generators = OrderedDict()
     for task in self.tasks:
       task_generators[task] = task.next_minibatch()
@@ -384,10 +381,8 @@ class AlternatingBatchMultiTaskTrainingRegimen(MultiTaskTrainingRegimen, Seriali
             src, trg = next(task_gen)
             self.trigger_train_event(True)
             loss_builder = cur_task.training_step(src, trg)
-            if update_weights:
-              self.backward(loss=loss_builder.compute(), dynet_profiling=self.dynet_profiling)
-          if update_weights:
-            self.update(trainer=self.trainer)
+            self.backward(loss=loss_builder.compute(), dynet_profiling=self.dynet_profiling)
+          self.update(trainer=self.trainer)
         cur_train_loss_tracker.report(trg, loss_builder.get_factored_loss_val(comb_method=self.loss_comb_method))
         self.checkpoint_and_save(cur_task, cur_task_i, save_fct, dev_zero)
         if self.tasks[0].should_stop_training(): break
@@ -429,7 +424,7 @@ class SerialMultiTaskTrainingRegimen(MultiTaskTrainingRegimen, Serializable):
     self.train_loss_trackers = {task: TrainLossTracker(task) for task in tasks}
     self.loss_comb_method = loss_comb_method
 
-  def run_training(self, save_fct, update_weights=True):
+  def run_training(self, save_fct):
     dev_zero = {i:self.dev_zero for i in range(len(self.tasks))}
     for cur_task_id in range(len(self.tasks)):
       self.train = None
@@ -445,9 +440,8 @@ class SerialMultiTaskTrainingRegimen(MultiTaskTrainingRegimen, Serializable):
             self.trigger_train_event(True)
             loss_builder = cur_task.training_step(src, trg)
             task_loss = loss_builder.compute()
-            if update_weights:
-              self.backward(task_loss, self.dynet_profiling)
-              self.update(self.trainer)
+            self.backward(task_loss, self.dynet_profiling)
+            self.update(self.trainer)
           cur_train_loss_tracker.report(trg, loss_builder.get_factored_loss_val(comb_method=self.loss_comb_method))
           self.checkpoint_and_save(cur_task, cur_task_id, save_fct, dev_zero)
           if cur_task.should_stop_training(): break


### PR DESCRIPTION
Previously, the same-batch regimen computed time/words jointly for all tasks. This PR computes and logs times individually if per_task_backward is activated.

In addition, includes a minor cleanup by removing the update_weights flag from the training regimens which was only used in one unit test, where the same effect is now achieved via a new DummyTrainer.