### PR TITLE
Several miscellaneous robustness fixes

### DIFF
--- a/xnmt/experiment.py
+++ b/xnmt/experiment.py
@@ -51,7 +51,7 @@ class Experiment(Serializable):
     eval_scores = ["Not evaluated"]
     if self.train:
       logger.info("> Training")
-      save_fct() # save initial model
+      # save_fct() # save initial model
       self.train.run_training(save_fct = save_fct)
       logger.info('reverting learned weights to best checkpoint..')
       ParamManager.param_col.revert_to_best_model()

--- a/xnmt/experiment.py
+++ b/xnmt/experiment.py
@@ -4,7 +4,7 @@ from xnmt import logger
 from xnmt.exp_global import ExpGlobal
 from xnmt.eval_task import EvalTask
 from xnmt.model_base import GeneratorModel
-from xnmt.param_collection import ParamManager
+from xnmt.param_collection import ParamManager, RevertingUnsavedModelException
 from xnmt.preproc_runner import PreprocRunner
 from xnmt.training_regimen import TrainingRegimen
 from xnmt.persistence import serializable_init, Serializable, bare
@@ -51,10 +51,12 @@ class Experiment(Serializable):
     eval_scores = ["Not evaluated"]
     if self.train:
       logger.info("> Training")
-      # save_fct() # save initial model
       self.train.run_training(save_fct = save_fct)
       logger.info('reverting learned weights to best checkpoint..')
-      ParamManager.param_col.revert_to_best_model()
+      try:
+        ParamManager.param_col.revert_to_best_model()
+      except RevertingUnsavedModelException:
+        pass
 
     evaluate_args = self.evaluate
     if evaluate_args:

--- a/xnmt/inference.py
+++ b/xnmt/inference.py
@@ -7,7 +7,7 @@ import dynet as dy
 
 import xnmt.input
 import xnmt.batcher
-from xnmt import loss, loss_calculator, model_base, output, reports, search_strategy, vocab, util
+from xnmt import logger, loss, loss_calculator, model_base, output, reports, search_strategy, vocab, util
 from xnmt.persistence import serializable_init, Serializable, Ref, bare
 
 NO_DECODING_ATTEMPTED = "@@NO_DECODING_ATTEMPTED@@"
@@ -64,6 +64,8 @@ class Inference(object):
     src_file = src_file or self.src_file
     trg_file = trg_file or self.trg_file
     util.make_parent_dir(trg_file)
+
+    logger.info(f'Performing inference on {src_file}')
 
     ref_corpus, src_corpus = self._read_corpus(generator, src_file, mode=self.mode, ref_file=self.ref_file)
 

--- a/xnmt/input_reader.py
+++ b/xnmt/input_reader.py
@@ -112,8 +112,9 @@ class PlainTextReader(BaseTextReader, Serializable):
 
   def read_sent(self, line):
     vocab_reference = self.vocab if self.include_vocab_reference else None
-    return SimpleSentenceInput([self.vocab.convert(word) for word in line.strip().split()] + \
-                                                       [self.vocab.convert(Vocab.ES_STR)], vocab_reference)
+    words = line.strip().split()
+    ids = [self.vocab.convert(word) for word in words] + [self.vocab.convert(Vocab.ES_STR)]
+    return SimpleSentenceInput(ids, vocab_reference)
 
   def freeze(self):
     self.vocab.freeze()

--- a/xnmt/optimizer.py
+++ b/xnmt/optimizer.py
@@ -34,10 +34,16 @@ class XnmtOptimizer(object):
     """
     Update the parameters.
     """
-    if not (self.skip_noisy and self._check_gradients_noisy()):
-      self.optimizer.update()
-    else:
-      logger.info("skipping noisy update")
+    try:
+      if not (self.skip_noisy and self._check_gradients_noisy()):
+        self.optimizer.update()
+      else:
+        logger.info("skipping noisy update")
+    except RuntimeError:
+      logger.warning("Failed to perform update. Skipping example and clearing gradients.")
+      for subcol in ParamManager.param_col.subcols.values():
+        for param in subcol.parameters_list():
+          param.scale_gradient(0)
 
   def status(self):
     """

--- a/xnmt/param_collection.py
+++ b/xnmt/param_collection.py
@@ -145,7 +145,8 @@ class ParamCollection(object):
   def add_subcollection(self, subcol_owner, subcol_name):
     assert subcol_owner not in self.all_subcol_owners
     self.all_subcol_owners.add(subcol_owner)
-    assert subcol_name not in self.subcols
+    if subcol_name in self.subcols:
+      raise RuntimeError(f'Duplicate subcol_name {subcol_name} found when loading')
     new_subcol = self._param_col.add_subcollection(subcol_name)
     self.subcols[subcol_name] = new_subcol
     return new_subcol

--- a/xnmt/param_collection.py
+++ b/xnmt/param_collection.py
@@ -166,7 +166,7 @@ class ParamCollection(object):
 
   def revert_to_best_model(self):
     if not self._is_saved:
-      raise ValueError("revert_to_best_model() is illegal because this model has never been saved.")
+      raise RevertingUnsavedModelException("revert_to_best_model() is illegal because this model has never been saved.")
     for subcol_name, subcol in self.subcols.items():
       subcol.populate(os.path.join(self._data_files[0], subcol_name))
 
@@ -193,3 +193,5 @@ class ParamCollection(object):
     for i in range(len(self._data_files)-1)[::-1]:
       if os.path.exists(self._data_files[i]):
         os.rename(self._data_files[i], self._data_files[i+1])
+
+class RevertingUnsavedModelException(Exception): pass


### PR DESCRIPTION
This PR has a bunch of fixes for robustness when doing lots of experiments. Probably only one is debatable, commenting out the initial model saving when starting training (`experiment.py`). I actually wasn't sure why this was necessary in the first place, and it can significantly slow down the start of training (and by proxy, the speed of debugging implementation).