### PR TITLE
initial implementation of repeat syntax

### DIFF
--- a/test/test_persistence.py
+++ b/test/test_persistence.py
@@ -180,7 +180,7 @@ class TestPreloader(unittest.TestCase):
     with open(f"{self.out_dir}/tmp1.yaml", "w") as f_out:
       yaml.dump(DummyClass(arg1="v1"), f_out)
     test_obj = yaml.load(f"!LoadSerialized {{ filename: {self.out_dir}/tmp1.yaml }}")
-    loaded_obj = YamlPreloader._load_referenced_serialized(test_obj)
+    loaded_obj = YamlPreloader._load_serialized(test_obj)
     self.assertIsInstance(loaded_obj, DummyClass)
     self.assertEqual(loaded_obj.arg1, "v1")
 
@@ -196,7 +196,7 @@ class TestPreloader(unittest.TestCase):
         val: !LoadSerialized
               filename: {self.out_dir}/tmp1.yaml
     """)
-    loaded_obj = YamlPreloader._load_referenced_serialized(test_obj)
+    loaded_obj = YamlPreloader._load_serialized(test_obj)
     self.assertIsInstance(loaded_obj["b"], DummyClass)
     self.assertIsInstance(loaded_obj["b"].arg1, DummyClass)
 


### PR DESCRIPTION
As mentioned in #467.

A test of a simple configuration with the following encoder seemed to work:
```
    encoder: !ModularSeqTransducer
      modules: !Repeat
        times: 3
        content: !BiLSTMSeqTransducer {}
```

@neubig could you take a look if this will work as expected for the multilayer transformer configs?