### PR TITLE
Added MLP convenience class

### DIFF
--- a/examples/21_self_attention.yaml
+++ b/examples/21_self_attention.yaml
@@ -48,7 +48,7 @@ self_attention: !Experiment
             - !ResidualSeqTransducer
               input_dim: 512
               child: !TransformSeqTransducer
-                transform: !MultiLayerPerceptron
+                transform: !MLP
                   activation: relu
               layer_norm: True
     attender: !MlpAttender

--- a/examples/21_self_attention.yaml
+++ b/examples/21_self_attention.yaml
@@ -35,38 +35,22 @@ self_attention: !Experiment
       - !PositionalSeqTransducer
         input_dim: 512
         max_pos: 100
-      - !ResidualSeqTransducer
-        input_dim: 512
-        child: !MultiHeadAttentionSeqTransducer
-          num_heads: 8
-        layer_norm: True
-      - !ResidualSeqTransducer
-        input_dim: 512
-        child: !ModularSeqTransducer
-          input_dim: 512
-          modules:
-          - !TransformSeqTransducer
-            transform: !NonLinear
-              activation: relu
-          - !TransformSeqTransducer
-            transform: !Linear {}
-        layer_norm: True
-      - !ResidualSeqTransducer
-        input_dim: 512
-        child: !MultiHeadAttentionSeqTransducer
-          num_heads: 8
-        layer_norm: True
-      - !ResidualSeqTransducer
-        input_dim: 512
-        child: !ModularSeqTransducer
-          input_dim: 512
-          modules:
-          - !TransformSeqTransducer
-            transform: !NonLinear
-              activation: relu
-          - !TransformSeqTransducer
-            transform: !Linear {}
-        layer_norm: True
+      - !ModularSeqTransducer
+        modules: !Repeat
+          times: 2
+          content: !ModularSeqTransducer
+            modules:
+            - !ResidualSeqTransducer
+              input_dim: 512
+              child: !MultiHeadAttentionSeqTransducer
+                num_heads: 8
+              layer_norm: True
+            - !ResidualSeqTransducer
+              input_dim: 512
+              child: !TransformSeqTransducer
+                transform: !MultiLayerPerceptron
+                  activation: relu
+              layer_norm: True
     attender: !MlpAttender
       hidden_dim: 512
       state_dim: 512

--- a/xnmt/classifier.py
+++ b/xnmt/classifier.py
@@ -9,7 +9,7 @@ class SequenceClassifier(model_base.ConditionedModel, model_base.GeneratorModel,
   """
   A sequence classifier.
 
-  Runs embeddings through an encoder, feeds the average over all encoder outputs to a MLP softmax output layer.
+  Runs embeddings through an encoder, feeds the average over all encoder outputs to a transform and scoring layer.
 
   Args:
     src_reader: A reader for the source side.
@@ -17,7 +17,8 @@ class SequenceClassifier(model_base.ConditionedModel, model_base.GeneratorModel,
     src_embedder: A word embedder for the input language
     encoder: An encoder to generate encoded inputs
     inference: how to perform inference
-    mlp: final prediction MLP layer
+    transform: A transform performed before the scoring function
+    scorer: A scoring function over the multiple choices
   """
 
   yaml_tag = '!SequenceClassifier'

--- a/xnmt/transform.py
+++ b/xnmt/transform.py
@@ -165,12 +165,12 @@ class AuxNonLinear(NonLinear, Serializable):
     )
     self.save_processed_arg("input_dim", original_input_dim)
 
-class MultiLayerPerceptron(Transform, Serializable):
+class MLP(Transform, Serializable):
   """
   A multi-layer perceptron. Defined as one or more NonLinear transforms of equal hidden
   dimension and type, then a Linear transform to the output dimension.
   """
-  yaml_tag = "!MultiLayerPerceptron"
+  yaml_tag = "!MLP"
 
   @serializable_init
   def __init__(self,


### PR DESCRIPTION
This makes the transformer encoder more compact by using the repeat syntax and adding an MLP Transform convenience class that performs 0 or more non-linear transforms, then a linear transform.