### PR TITLE
Named experiments and resume option

### DIFF
--- a/docs/experiment_config_files.rst
+++ b/docs/experiment_config_files.rst
@@ -151,7 +151,13 @@ Minimal
 Multiple experiments
 ~~~~~~~~~~~~~~~~~~~~
 
-.. literalinclude:: examples/03_multiple_exp.yaml
+.. literalinclude:: examples/03a_multiple_exp.yaml
+    :language: yaml
+
+.. literalinclude:: examples/03b_multiple_exp.yaml
+    :language: yaml
+
+.. literalinclude:: examples/03c_multiple_exp.yaml
     :language: yaml
 
 Settings
@@ -231,6 +237,8 @@ Scoring N-best lists
 Transformer
 ~~~~~~~~~~~
 
+(this is currently broken)
+
 .. literalinclude:: examples/16_transformer.yaml
     :language: yaml
 
@@ -240,11 +248,35 @@ Ensembling
 .. literalinclude:: examples/17_ensembling.yaml
     :language: yaml
 
-
 Minimum risk training
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. literalinclude:: examples/18_minrisk.yaml
     :language: yaml
 
+Biased Lexicon
+~~~~~~~~~~~~~~
+
+(this is currently broken)
+
+.. literalinclude:: examples/19_lexiconbias.yaml
+    :language: yaml
+
+Subword Sampling
+~~~~~~~~~~~~~~~~
+
+.. literalinclude:: examples/20_subword_sample.yaml
+    :language: yaml
+
+Self Attention
+~~~~~~~~~~~~~~
+
+.. literalinclude:: examples/21_self_attention.yaml
+    :language: yaml
+
+Char Segment
+~~~~~~~~~~~~
+
+.. literalinclude:: examples/22_char_segment.yaml
+    :language: yaml
 

--- a/docs/experiment_config_files.rst
+++ b/docs/experiment_config_files.rst
@@ -7,7 +7,7 @@ Configuration files are in `YAML format <https://docs.ansible.com/ansible/YAMLSy
 
 At the top-level, a config file consists of a dictionary where keys are experiment
 names and values are the experiment specifications. By default, all experiments
-are run in lexicographical ordering, but xnmt_run_experiments can also be told
+are run in lexicographical ordering, but ``xnmt_run_experiments`` can also be told
 to run only a selection of the specified experiments. An example template with
 2 experiments looks like this
 
@@ -35,6 +35,7 @@ using YAML anchors or the !Ref mechanism (more on this later).
 The usage of ``exp_global``, ``preproc``, ``model``, ``train``, ``evaluate``
 are explained below.
 Not all of them need to be specified, depending on the use case.
+
 
 Experiment
 ==========
@@ -129,27 +130,41 @@ Evaluation
 ==========
 If specified, the model is tested after training finished.
 
+Config files vs. saved model files
+----------------------------------
+Saved model files are written out in the exact same YAML format as the config files (with the addition
+of some .data directories that contain DyNet weights). This means that it is possible to specify a
+saved model as the configuration file. There is one subtle difference: In a config file, placeholders
+such as ``{EXP_DIR}`` are resolved based on the current context, which will be different when directly
+specifying the saved model file as config file. For this purpose a ``--resume`` option exists that
+makes sure to use the context from the saved model file: ``xnmt --resume /path/to/saved-model.mod``.
+
+This feature is currently implemented only in a very basic form: When resuming a crashed experiment,
+this will cause the whole experiment to be carried out from the start. When resuming a finished
+experiment, *xnmt* will return without performing any action. In the future, this will be extended to
+support resuming from the most recent saved checkpoint, etc.
+
 Examples
-========
+--------
 
 Here are more elaborate examples from the github repository.
 
 .. _ex-standard:
 
 Standard
-~~~~~~~~
+========
 
 .. literalinclude:: examples/01_standard.yaml
     :language: yaml
 
 Minimal
-~~~~~~~
+=======
 
 .. literalinclude:: examples/02_minimal.yaml
     :language: yaml
 
 Multiple experiments
-~~~~~~~~~~~~~~~~~~~~
+====================
 
 .. literalinclude:: examples/03a_multiple_exp.yaml
     :language: yaml
@@ -161,49 +176,49 @@ Multiple experiments
     :language: yaml
 
 Settings
-~~~~~~~~
+========
 
 .. literalinclude:: examples/04_settings.yaml
     :language: yaml
 
 Preprocessing
-~~~~~~~~~~~~~
+=============
 
 .. literalinclude:: examples/05_preproc.yaml
     :language: yaml
 
 Early stopping
-~~~~~~~~~~~~~~
+==============
 
 .. literalinclude:: examples/06_early_stopping.yaml
     :language: yaml
 
 Fine-tuning
-~~~~~~~~~~~
+===========
 
 .. literalinclude:: examples/07_load_finetune.yaml
     :language: yaml
 
 Beam search
-~~~~~~~~~~~
+===========
 
 .. literalinclude:: examples/08_load_eval_beam.yaml
     :language: yaml
 
 Programmatic usage
-~~~~~~~~~~~~~~~~~~
+==================
 
 .. literalinclude:: examples/09_programmatic.py
     :language: python
 
 Programmatic loading
-~~~~~~~~~~~~~~~~~~~~
+====================
 
 .. literalinclude:: examples/10_programmatic_load.py
     :language: python
 
 Parameter sharing
-~~~~~~~~~~~~~~~~~~~~
+=================
 
 .. literalinclude:: examples/11_component_sharing.yaml
     :language: yaml
@@ -211,31 +226,31 @@ Parameter sharing
 .. _ex-multi-task:
 
 Multi-task
-~~~~~~~~~~~~~~~~~~~~
+==========
 
 .. literalinclude:: examples/12_multi_task.yaml
     :language: yaml
 
 Speech
-~~~~~~~~~~~~~~~~~~~~
+======
 
 .. literalinclude:: examples/13_speech.yaml
     :language: yaml
 
 Reporting attention matrices
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+============================
 
 .. literalinclude:: examples/14_report.yaml
     :language: yaml
 
 Scoring N-best lists
-~~~~~~~~~~~~~~~~~~~~
+====================
 
 .. literalinclude:: examples/15_score.yaml
     :language: yaml
 
 Transformer
-~~~~~~~~~~~
+===========
 
 (this is currently broken)
 
@@ -243,19 +258,19 @@ Transformer
     :language: yaml
 
 Ensembling
-~~~~~~~~~~
+==========
 
 .. literalinclude:: examples/17_ensembling.yaml
     :language: yaml
 
 Minimum risk training
-~~~~~~~~~~~~~~~~~~~~~
+=====================
 
 .. literalinclude:: examples/18_minrisk.yaml
     :language: yaml
 
 Biased Lexicon
-~~~~~~~~~~~~~~
+==============
 
 (this is currently broken)
 
@@ -263,19 +278,19 @@ Biased Lexicon
     :language: yaml
 
 Subword Sampling
-~~~~~~~~~~~~~~~~
+================
 
 .. literalinclude:: examples/20_subword_sample.yaml
     :language: yaml
 
 Self Attention
-~~~~~~~~~~~~~~
+==============
 
 .. literalinclude:: examples/21_self_attention.yaml
     :language: yaml
 
 Char Segment
-~~~~~~~~~~~~
+============
 
 .. literalinclude:: examples/22_char_segment.yaml
     :language: yaml

--- a/examples/01_standard.yaml
+++ b/examples/01_standard.yaml
@@ -1,6 +1,7 @@
 # A standard setup, specifying model architecture, training parameters, 
 # and evaluation of the trained model
-standard: !Experiment # 'standard' is the name given to the experiment
+!Experiment # 'standard' is the name given to the experiment
+  name: standard # every experiment needs a name
   # global parameters shared throughout the experiment
   exp_global: !ExpGlobal
     # {EXP_DIR} is a placeholder for the directory in which the config file lies.

--- a/examples/02_minimal.yaml
+++ b/examples/02_minimal.yaml
@@ -6,7 +6,8 @@
 # For example,xnmt.translator.DefaultTranslator.__init__()
 # specifies MlpAttender as the default attender, which will be used in this
 # examples since nothing is specified.
-minimal: !Experiment
+!Experiment
+  name: minimal
   model: !DefaultTranslator
     src_reader: !PlainTextReader
       vocab: !Vocab {vocab_file: examples/data/head.ja.vocab}

--- a/examples/03a_multiple_exp.yaml
+++ b/examples/03a_multiple_exp.yaml
@@ -1,0 +1,45 @@
+# A config file can contain multiple experiments.
+# These are run in sequence.
+# It's also possible to run experiments in parallel:
+# by default, experiments are skipped when the corresponding log file already
+# exists, i.e. when the experiment is currently running or has already finnished.
+# That means it's safe to run ``xnmt my_config.yaml`` on the same config file
+# multiple times.
+#
+# This particular examples runs the same experiment, changing only the amount
+# of dropout. model, train, evaluate settings are shared using YAML anchors,
+# see here for more information: http://yaml.readthedocs.io/en/latest/example.html
+#
+# There are two ways of specifying multiple experiments: the dictionary-way and the
+# list-way. The dictionary-way is shown below. Here, dictionary keys are experiment
+# names and the values are !Experiment objects. The order is determined by lexicographic
+# ordering of the experiment names.
+exp1_dropout: !Experiment
+  exp_global: !ExpGlobal
+    dropout: 0.5
+  model: &my_model !DefaultTranslator
+    src_reader: !PlainTextReader
+      vocab: !Vocab {vocab_file: examples/data/head.ja.vocab}
+    trg_reader: !PlainTextReader
+      vocab: !Vocab {vocab_file: examples/data/head.en.vocab}
+  train: &my_train !SimpleTrainingRegimen
+    run_for_epochs: 2
+    src_file: examples/data/head.ja
+    trg_file: examples/data/head.en
+    dev_tasks:
+      - !LossEvalTask
+        src_file: examples/data/head.ja
+        ref_file: examples/data/head.en
+  evaluate: &my_eval
+    - !AccuracyEvalTask
+      eval_metrics: bleu
+      src_file: examples/data/head.ja
+      ref_file: examples/data/head.en
+      hyp_file: examples/output/{EXP}.test_hyp
+
+exp2_no_dropout: !Experiment
+  exp_global: !ExpGlobal
+    dropout: 0.0
+  model: *my_model
+  train: *my_train
+  evaluate: *my_eval

--- a/examples/03b_multiple_exp.yaml
+++ b/examples/03b_multiple_exp.yaml
@@ -1,16 +1,8 @@
-# A config file can contain multiple experiments.
-# These are run in sequence, where the order is determined by lexicographic
-# ordering of the experiment names.
-# It's also possible to run experiments in parallel:
-# by default, experiments are skipped when the corresponding log file already
-# exists, i.e. when the experiment is currently running or has already finnished.
-# That means it's safe to run ``xnmt my_config.yaml`` on the same config file
-# multiple times.
-#
-# This particular examples runs the same experiment, changing only the amount
-# of dropout. model, train, evaluate settings are shared using YAML anchors,
-# see here for more information: http://yaml.readthedocs.io/en/latest/example.html
-exp1_dropout: !Experiment
+# This example demonstrates specifying multiple experiments as a list.
+# Here, the list makes the order of experiments explicit.
+# Experiment names have to be passed as arguments to !Experiment
+- !Experiment
+  name: exp1_dropout
   exp_global: !ExpGlobal
     dropout: 0.5
   model: &my_model !DefaultTranslator
@@ -33,7 +25,8 @@ exp1_dropout: !Experiment
       ref_file: examples/data/head.en
       hyp_file: examples/output/{EXP}.test_hyp
 
-exp2_no_dropout: !Experiment
+- !Experiment
+  name: exp2_no_dropout
   exp_global: !ExpGlobal
     dropout: 0.0
   model: *my_model

--- a/examples/03c_multiple_exp.yaml
+++ b/examples/03c_multiple_exp.yaml
@@ -1,0 +1,25 @@
+# Finally, it's possible to specify a single experiment as top-level entry,
+# where again the experiment name has to be passed as an argument.
+!Experiment
+  name: exp1_dropout
+  exp_global: !ExpGlobal
+    dropout: 0.5
+  model: &my_model !DefaultTranslator
+    src_reader: !PlainTextReader
+      vocab: !Vocab {vocab_file: examples/data/head.ja.vocab}
+    trg_reader: !PlainTextReader
+      vocab: !Vocab {vocab_file: examples/data/head.en.vocab}
+  train: &my_train !SimpleTrainingRegimen
+    run_for_epochs: 2
+    src_file: examples/data/head.ja
+    trg_file: examples/data/head.en
+    dev_tasks:
+      - !LossEvalTask
+        src_file: examples/data/head.ja
+        ref_file: examples/data/head.en
+  evaluate: &my_eval
+    - !AccuracyEvalTask
+      eval_metrics: bleu
+      src_file: examples/data/head.ja
+      ref_file: examples/data/head.en
+      hyp_file: examples/output/{EXP}.test_hyp

--- a/examples/04_settings.yaml
+++ b/examples/04_settings.yaml
@@ -7,7 +7,8 @@
 # ``xnmt --settings=debug examples/04_settings.yaml``
 # 
 # It is easy to change behavior by either changing these configurations, or adding a new configuration to the module.
-settings-exp: !Experiment
+!Experiment
+  name: settings-exp
   model: !DefaultTranslator
     src_reader: !PlainTextReader
       vocab: !Vocab {vocab_file: examples/data/head.ja.vocab}

--- a/examples/05_preproc.yaml
+++ b/examples/05_preproc.yaml
@@ -1,6 +1,7 @@
 # XNMT supports various ways to preprocess data as demonstrated in this example.
 # Note that some preprocessing functionality relies on third-party tools.
-preproc: !Experiment
+!Experiment
+  name: preproc
   exp_global: !ExpGlobal
     # define some named strings that can be used throughout the experiment config:
     placeholders:

--- a/examples/06_early_stopping.yaml
+++ b/examples/06_early_stopping.yaml
@@ -5,7 +5,8 @@
 # - patience
 # - initial_patience
 # - dev_tasks (to configure the metric used to determine lr decay or early stopping)
-minimal: !Experiment
+!Experiment
+  name: minimal-early-stopping
   model: !DefaultTranslator
     src_reader: !PlainTextReader
       vocab: !Vocab {vocab_file: examples/data/head.ja.vocab}

--- a/examples/09_programmatic.py
+++ b/examples/09_programmatic.py
@@ -103,6 +103,7 @@ evaluate = [AccuracyEvalTask(eval_metrics="bleu,wer",
                              model=model)]
 
 standard_experiment = Experiment(
+  name="programmatic",
   model=model,
   train=train,
   evaluate=evaluate

--- a/examples/13_speech.yaml
+++ b/examples/13_speech.yaml
@@ -4,7 +4,8 @@
 # instead directly read in a feature vector the pyramidal LSTM reduces length of
 # the input sequence by a factor of 2 per layer (except for the first layer).
 # Output units should be characters according to the paper.
-speech: !Experiment
+!Experiment
+  name: speech
   exp_global: !ExpGlobal
     save_num_checkpoints: 2
     default_layer_dim: 32

--- a/examples/14_report.yaml
+++ b/examples/14_report.yaml
@@ -2,7 +2,8 @@
 # between outputs and references.
 # These are generally created by setting exp_global.compute_report to True, and adding one or several reporters
 # to the inference class.
-report: !Experiment
+!Experiment
+  name: report
   exp_global: !ExpGlobal
     compute_report: True
   model: !DefaultTranslator

--- a/examples/20_subword_sample.yaml
+++ b/examples/20_subword_sample.yaml
@@ -1,6 +1,7 @@
 # Sampling subword units for subword regularization
 # Note that this requires 'sentencepiece' as an extra dependency
-subword_sample: !Experiment 
+!Experiment
+  name: subword_sample
   exp_global: !ExpGlobal
     model_file: '{EXP_DIR}/models/{EXP}.mod'
     log_file: '{EXP_DIR}/logs/{EXP}.log'

--- a/examples/21_self_attention.yaml
+++ b/examples/21_self_attention.yaml
@@ -1,5 +1,6 @@
 # A setup using self-attention
-self_attention: !Experiment
+!Experiment
+  name: self_attention
   exp_global: !ExpGlobal
     model_file: '{EXP_DIR}/models/{EXP}.mod'
     log_file: '{EXP_DIR}/logs/{EXP}.log'

--- a/xnmt/experiments.py
+++ b/xnmt/experiments.py
@@ -72,6 +72,7 @@ class Experiment(Serializable):
   __call__() runs the individual steps.
 
   Args:
+    name: name of experiment
     exp_global: global experiment settings
     preproc: carry out preprocessing if specified
     model: The main model. In the case of multitask training, several models must be specified, in which case the models will live not here but inside the training task objects.
@@ -84,12 +85,14 @@ class Experiment(Serializable):
 
   @serializable_init
   def __init__(self,
+               name: str,
                exp_global:Optional[ExpGlobal] = bare(ExpGlobal),
                preproc:Optional[PreprocRunner] = None,
                model:Optional[TrainableModel] = None,
                train:Optional[TrainingRegimen] = None,
                evaluate:Optional[List[EvalTask]] = None,
                random_search_report:Optional[dict] = None) -> None:
+    self.name = name
     self.exp_global = exp_global
     self.preproc = preproc
     self.model = model

--- a/xnmt/experiments.py
+++ b/xnmt/experiments.py
@@ -63,7 +63,6 @@ class ExpGlobal(Serializable):
     self.compute_report = compute_report
     self.placeholders = placeholders
 
-
 class Experiment(Serializable):
   """
   A default experiment that performs preprocessing, training, and evaluation.
@@ -91,13 +90,15 @@ class Experiment(Serializable):
                model:Optional[TrainableModel] = None,
                train:Optional[TrainingRegimen] = None,
                evaluate:Optional[List[EvalTask]] = None,
-               random_search_report:Optional[dict] = None) -> None:
+               random_search_report:Optional[dict] = None,
+               status=None) -> None:
     self.name = name
     self.exp_global = exp_global
     self.preproc = preproc
     self.model = model
     self.train = train
     self.evaluate = evaluate
+    self.status = status
 
     if random_search_report:
       logger.info(f"> instantiated random parameter search: {random_search_report}")
@@ -107,25 +108,31 @@ class Experiment(Serializable):
     Launch training loop, followed by final evaluation.
     """
     eval_scores = ["Not evaluated"]
-    if self.train:
-      logger.info("> Training")
-      self.train.run_training(save_fct = save_fct)
-      logger.info('reverting learned weights to best checkpoint..')
-      try:
-        ParamManager.param_col.revert_to_best_model()
-      except RevertingUnsavedModelException:
-        pass
+    if self.status != "done":
+      if self.train:
+        logger.info("> Training")
+        self.train.run_training(save_fct = save_fct)
+        logger.info('reverting learned weights to best checkpoint..')
+        try:
+          ParamManager.param_col.revert_to_best_model()
+        except RevertingUnsavedModelException:
+          pass
 
-    evaluate_args = self.evaluate
-    if evaluate_args:
-      logger.info("> Performing final evaluation")
-      eval_scores = []
-      for evaluator in evaluate_args:
-        eval_score = evaluator.eval()
-        if type(eval_score) == list:
-          eval_scores.extend(eval_score)
-        else:
-          eval_scores.append(eval_score)
+      evaluate_args = self.evaluate
+      if evaluate_args:
+        logger.info("> Performing final evaluation")
+        eval_scores = []
+        for evaluator in evaluate_args:
+          eval_score = evaluator.eval()
+          if type(eval_score) == list:
+            eval_scores.extend(eval_score)
+          else:
+            eval_scores.append(eval_score)
+
+      self.save_processed_arg("status", "done")
+      save_fct()
+    else:
+      logger.info("Experiment already finished, skipping.")
 
     return eval_scores
 

--- a/xnmt/xnmt_run_experiments.py
+++ b/xnmt/xnmt_run_experiments.py
@@ -37,6 +37,8 @@ def main(overwrite_args=None):
     argparser.add_argument("--settings", type=str, default="standard", help="settings (standard, debug, or unittest)"
                                                                             "must be given in '=' syntax, e.g."
                                                                             " --settings=standard")
+    argparser.add_argument("--resume", action='store_true', help="whether a saved experiment is being resumed, and"
+                                                                 "locations of output files should be re-used.")
     argparser.add_argument("experiments_file")
     argparser.add_argument("experiment_name", nargs='*', help="Run only the specified experiments")
     argparser.set_defaults(generate_doc=False)
@@ -68,7 +70,8 @@ def main(overwrite_args=None):
 
       ParamManager.init_param_col()
 
-      uninitialized_exp_args = YamlPreloader.preload_experiment_from_file(args.experiments_file, experiment_name)
+      uninitialized_exp_args = YamlPreloader.preload_experiment_from_file(args.experiments_file, experiment_name,
+                                                                          resume=args.resume)
 
       logger.info(f"=> Running {experiment_name}")
 


### PR DESCRIPTION
This is a proof-of-concept for #367 / #383:

- config files can now be single experiments, lists of experiments, or (as before) dictionaries of experiments. In the first 2 cases, experiments have to have a name argument, and the third case the name argument is taken from the dictionary key.
- this allows us to call ```xnmt /path/to/saved-model.mod``` which will resume the previous experiment.
- ```Experiment``` now has a simple state that checks whether everything is finished or not. If resuming a finished experiment, nothing will happen, otherwise the whole experiment is carried out.
- a ```--resume``` flag is added that makes sure that ```{EXP_DIR}```, ```{EXP}``` etc. is set to the value that was previously used, rather than to the values corresponding to the current context. This makes sure that locations of model and log files are the same as before.

In order to resume crashed trainings etc., all that's missing is for the training regimen to keep track of its state in a similar way and resume rather than start from the beginning if appropriate. This is actually not super easy so I'll leave it for a future commit.

One question I had is whether it's possible to write out the state of the DyNet trainer? Otherwise resuming a training would not produce the same results as running it without interruption.