### PR TITLE
Fix a bug when saving models

### DIFF
--- a/test/test_persistence.py
+++ b/test/test_persistence.py
@@ -278,7 +278,19 @@ class TestSaving(unittest.TestCase):
     param_collections.ParamManager.init_param_col()
     param_collections.ParamManager.param_col.model_file = self.model_file
 
-  def test_1(self):
+  def test_shallow(self):
+    test_obj = yaml.load("""
+                         a: !DummyArgClass
+                           arg1: !DummyArgClass2
+                             _xnmt_id: id1
+                             v: some_val
+                           arg2: !Ref { name: id1 }
+                         """)
+    preloaded = YamlPreloader.preload_obj(root=test_obj,exp_name="exp1",exp_dir=self.out_dir)
+    initalized = initialize_if_needed(preloaded)
+    save_to_file(self.model_file, initalized)
+
+  def test_mid(self):
     test_obj = yaml.load("""
                          a: !DummyArgClass
                            arg1: !DummyArgClass2
@@ -291,7 +303,22 @@ class TestSaving(unittest.TestCase):
     preloaded = YamlPreloader.preload_obj(root=test_obj,exp_name="exp1",exp_dir=self.out_dir)
     initalized = initialize_if_needed(preloaded)
     save_to_file(self.model_file, initalized)
-    print("break")
+
+  def test_deep(self):
+    test_obj = yaml.load("""
+                         a: !DummyArgClass
+                           arg1: !DummyArgClass2
+                             v: !DummyArgClass2
+                               v: !DummyArgClass2
+                                 _xnmt_id: id1
+                                 v: some_val
+                           arg2: !DummyArgClass2
+                             v: !DummyArgClass2
+                               v: !Ref { name: id1 }
+                         """)
+    preloaded = YamlPreloader.preload_obj(root=test_obj,exp_name="exp1",exp_dir=self.out_dir)
+    initalized = initialize_if_needed(preloaded)
+    save_to_file(self.model_file, initalized)
 
   def tearDown(self):
     try:

--- a/xnmt/persistence.py
+++ b/xnmt/persistence.py
@@ -541,9 +541,12 @@ def _get_child_dict(node, name):
 
 @_get_child.register(Serializable)
 def _get_child_serializable(node, name):
-  if not hasattr(node, name):
-    raise PathError(f"{node} has no child named {name}")
-  return getattr(node, name)
+  if hasattr(node, "serialize_params"):
+    return _get_child(node.serialize_params, name)
+  else:
+    if not hasattr(node, name):
+      raise PathError(f"{node} has no child named {name}")
+    return getattr(node, name)
 
 
 @singledispatch


### PR DESCRIPTION
Crashed under the following conditions:
- a model requires an argument which it does not keep as a member variable under the same name
- reference-sharing occurs one level down of this argument

Also included is a unit test to catch this.