### PR TITLE
fix models base interface

### DIFF
--- a/xnmt/eval/tasks.py
+++ b/xnmt/eval/tasks.py
@@ -85,13 +85,10 @@ class LossEvalTask(EvalTask, Serializable):
 
     loss_stats = {k: v/ref_words_cnt for k, v in loss_val.items()}
 
-    try:
-      return LossScore(loss_stats[self.model.get_primary_loss()],
-                       loss_stats=loss_stats,
-                       num_ref_words = ref_words_cnt,
-                       desc=self.desc)
-    except KeyError:
-      raise RuntimeError("Did you wrap your loss calculation with FactoredLossExpr({'primary_loss': loss_value}) ?")
+    return LossScore(sum(loss_stats.values()),
+                     loss_stats=loss_stats,
+                     num_ref_words = ref_words_cnt,
+                     desc=self.desc)
 
 class AccuracyEvalTask(EvalTask, reports.Reportable, Serializable):
   """

--- a/xnmt/models/base.py
+++ b/xnmt/models/base.py
@@ -1,5 +1,7 @@
 from typing import Optional, Sequence, Union
 
+import dynet as dy
+
 from xnmt import batchers, input_readers, losses, sent
 from xnmt import event_trigger, loss_calculators
 from xnmt.persistence import Serializable, serializable_init
@@ -9,7 +11,7 @@ class TrainableModel(object):
   A template class for a basic trainable model, implementing a loss function.
   """
 
-  def calc_nll(self, *args, **kwargs) -> losses.FactoredLossExpr:
+  def calc_nll(self, *args, **kwargs) -> dy.Expression:
     """Calculate loss based on input-output pairs.
 
     Losses are accumulated only across unmasked timesteps in each batch element.
@@ -19,13 +21,6 @@ class TrainableModel(object):
     Returns:
       A (possibly batched) expression representing the loss.
     """
-
-  def get_primary_loss(self) -> str:
-    """
-    Returns:
-      Identifier for primary loss.
-    """
-    raise NotImplementedError("Pick a key for primary loss that is used for dev_loss calculation")
 
 class UnconditionedModel(TrainableModel):
   """
@@ -38,7 +33,7 @@ class UnconditionedModel(TrainableModel):
   def __init__(self, trg_reader: input_readers.InputReader):
     self.trg_reader = trg_reader
 
-  def calc_nll(self, trg: Union[batchers.Batch, sent.Sentence]) -> losses.FactoredLossExpr:
+  def calc_nll(self, trg: Union[batchers.Batch, sent.Sentence]) -> dy.Expression:
     """Calculate loss based on target inputs.
 
     Losses are accumulated only across unmasked timesteps in each batch element.
@@ -64,8 +59,8 @@ class ConditionedModel(TrainableModel):
     self.src_reader = src_reader
     self.trg_reader = trg_reader
 
-  def calc_nll(self, src: Union[batchers.Batch, sent.Sentence], trg: Union[batchers.Batch, sent.Sentence],
-                loss_calculator: loss_calculators.LossCalculator) -> losses.FactoredLossExpr:
+  def calc_nll(self, src: Union[batchers.Batch, sent.Sentence], trg: Union[batchers.Batch, sent.Sentence]) \
+          -> dy.Expression:
     """Calculate loss based on input-output pairs.
 
     Losses are accumulated only across unmasked timesteps in each batch element.

--- a/xnmt/models/classifiers.py
+++ b/xnmt/models/classifiers.py
@@ -80,9 +80,6 @@ class SequenceClassifier(models.ConditionedModel, models.GeneratorModel, Seriali
                                          score=score))
     return outputs
 
-  def get_primary_loss(self):
-    return "mle"
-
   def get_nobp_state(self, state):
     output_state = state.rnn_state.output()
     return output_state

--- a/xnmt/models/language_models.py
+++ b/xnmt/models/language_models.py
@@ -41,9 +41,6 @@ class LanguageModel(models.ConditionedModel, Serializable):
   def shared_params(self):
     return [{".src_embedder.emb_dim", ".encoder.input_dim"},]
 
-  def get_primary_loss(self):
-    return "mle"
-
   def calc_nll(self, src, trg):
     if not batchers.is_batched(src):
       src = batchers.ListBatch([src])

--- a/xnmt/models/sequence_labelers.py
+++ b/xnmt/models/sequence_labelers.py
@@ -51,9 +51,6 @@ class SeqLabeler(models.ConditionedModel, models.GeneratorModel, Serializable, r
   def shared_params(self):
     return [{".src_embedder.emb_dim", ".encoder.input_dim"},]
 
-  def get_primary_loss(self):
-    return "mle"
-
   def _encode_src(self, src):
     event_trigger.start_sent(src)
     embeddings = self.src_embedder.embed_sent(src)

--- a/xnmt/models/translators.py
+++ b/xnmt/models/translators.py
@@ -355,7 +355,7 @@ class TransformerTranslator(AutoRegressiveTranslator, Serializable, Reportable):
     e = dy.reshape(e, (units, length), batch_size=batch)
     return e
 
-  def calc_loss(self, src, trg, loss_cal=None, infer_prediction=False):
+  def calc_loss(self, src, trg, infer_prediction=False):
     event_trigger.start_sent(src)
     if not batchers.is_batched(src):
       src = batchers.mark_as_batch([src])
@@ -488,7 +488,7 @@ class EnsembleTranslator(AutoRegressiveTranslator, Serializable):
   def calc_nll(self, src: Union[batchers.Batch, sent.Sentence], trg: Union[batchers.Batch, sent.Sentence]) -> dy.Expression:
     sub_losses = collections.defaultdict(list)
     for model in self.models:
-      for loss_name, loss in model.calc_loss(src, trg).expr_factors.items():
+      for loss_name, loss in model.calc_nll(src, trg).expr_factors.items():
         sub_losses[loss_name].append(loss)
     model_loss = FactoredLossExpr()
     for loss_name, losslist in sub_losses.items():

--- a/xnmt/models/translators.py
+++ b/xnmt/models/translators.py
@@ -60,9 +60,6 @@ class AutoRegressiveTranslator(base.ConditionedModel, base.GeneratorModel):
     """
     self.trg_vocab = trg_vocab
 
-  def get_primary_loss(self) -> str:
-    return "mle"
-
   def get_nobp_state(self, state):
     output_state = state.rnn_state.output()
     if type(output_state) == EnsembleListDelegate:


### PR DESCRIPTION
Will fix #507.

Is ```get_primary_loss``` still needed? The only place it's currently used is here, not sure if that's on purpose or was forgotten: https://github.com/neulab/xnmt/blob/master/xnmt/eval/tasks.py#L89