### PR TITLE
Tensorboard integration

### DIFF
--- a/docs/experiment_config_files.rst
+++ b/docs/experiment_config_files.rst
@@ -1,7 +1,10 @@
 .. _sec-exp-conf:
 
 Experiment configuration file format
-------------------------------------
+====================================
+
+Intro
+-----
 
 Configuration files are in `YAML format <https://docs.ansible.com/ansible/YAMLSyntax.html>`_.
 
@@ -38,7 +41,7 @@ Not all of them need to be specified, depending on the use case.
 
 
 Experiment
-==========
+~~~~~~~~~~
 
 This specifies settings that are global to this experiment. An example
 
@@ -59,13 +62,13 @@ To obtain a full list of allowed parameters, please check the documentation for
 :ref:`ExpGlobal <mod-experiments>`.
 
 Preprocessing
-=============
+~~~~~~~~~~~~~
 
 *xnmt* supports a variety of data preprocessing features. Please refer to
 :ref:`sec-preproc` for details.
 
 Model
-=====
+~~~~~
 This specifies the model architecture. An typical example looks like this
 
 .. code-block:: yaml
@@ -103,7 +106,7 @@ are initialized in the order they appear in the constructor. Among others,
 this guarantees that preprocessing is carried out before the model training.
 
 Training
-========
+~~~~~~~~
 
 A typical example looks like this
 
@@ -127,7 +130,7 @@ case models must be specified as sub-components of the training regimen. An exam
 :ref:`ex-multi-task` configuration can be refered to for more details on this.
 
 Evaluation
-==========
+~~~~~~~~~~
 If specified, the model is tested after training finished.
 
 Config files vs. saved model files
@@ -152,19 +155,19 @@ Here are more elaborate examples from the github repository.
 .. _ex-standard:
 
 Standard
-========
+~~~~~~~~
 
 .. literalinclude:: examples/01_standard.yaml
     :language: yaml
 
 Minimal
-=======
+~~~~~~~
 
 .. literalinclude:: examples/02_minimal.yaml
     :language: yaml
 
 Multiple experiments
-====================
+~~~~~~~~~~~~~~~~~~~~
 
 .. literalinclude:: examples/03a_multiple_exp.yaml
     :language: yaml
@@ -176,49 +179,49 @@ Multiple experiments
     :language: yaml
 
 Settings
-========
+~~~~~~~~
 
 .. literalinclude:: examples/04_settings.yaml
     :language: yaml
 
 Preprocessing
-=============
+~~~~~~~~~~~~~
 
 .. literalinclude:: examples/05_preproc.yaml
     :language: yaml
 
 Early stopping
-==============
+~~~~~~~~~~~~~~
 
 .. literalinclude:: examples/06_early_stopping.yaml
     :language: yaml
 
 Fine-tuning
-===========
+~~~~~~~~~~~
 
 .. literalinclude:: examples/07_load_finetune.yaml
     :language: yaml
 
 Beam search
-===========
+~~~~~~~~~~~
 
 .. literalinclude:: examples/08_load_eval_beam.yaml
     :language: yaml
 
 Programmatic usage
-==================
+~~~~~~~~~~~~~~~~~~
 
 .. literalinclude:: examples/09_programmatic.py
     :language: python
 
 Programmatic loading
-====================
+~~~~~~~~~~~~~~~~~~~~
 
 .. literalinclude:: examples/10_programmatic_load.py
     :language: python
 
 Parameter sharing
-=================
+~~~~~~~~~~~~~~~~~
 
 .. literalinclude:: examples/11_component_sharing.yaml
     :language: yaml
@@ -226,31 +229,31 @@ Parameter sharing
 .. _ex-multi-task:
 
 Multi-task
-==========
+~~~~~~~~~~
 
 .. literalinclude:: examples/12_multi_task.yaml
     :language: yaml
 
 Speech
-======
+~~~~~~
 
 .. literalinclude:: examples/13_speech.yaml
     :language: yaml
 
 Reporting attention matrices
-============================
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. literalinclude:: examples/14_report.yaml
     :language: yaml
 
 Scoring N-best lists
-====================
+~~~~~~~~~~~~~~~~~~~~
 
 .. literalinclude:: examples/15_score.yaml
     :language: yaml
 
 Transformer
-===========
+~~~~~~~~~~~
 
 (this is currently broken)
 
@@ -258,19 +261,19 @@ Transformer
     :language: yaml
 
 Ensembling
-==========
+~~~~~~~~~~
 
 .. literalinclude:: examples/17_ensembling.yaml
     :language: yaml
 
 Minimum risk training
-=====================
+~~~~~~~~~~~~~~~~~~~~~
 
 .. literalinclude:: examples/18_minrisk.yaml
     :language: yaml
 
 Biased Lexicon
-==============
+~~~~~~~~~~~~~~
 
 (this is currently broken)
 
@@ -278,19 +281,19 @@ Biased Lexicon
     :language: yaml
 
 Subword Sampling
-================
+~~~~~~~~~~~~~~~~
 
 .. literalinclude:: examples/20_subword_sample.yaml
     :language: yaml
 
 Self Attention
-==============
+~~~~~~~~~~~~~~
 
 .. literalinclude:: examples/21_self_attention.yaml
     :language: yaml
 
 Char Segment
-============
+~~~~~~~~~~~~
 
 .. literalinclude:: examples/22_char_segment.yaml
     :language: yaml

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ It is coded in Python based on `DyNet <http://github.com/clab/dynet>`_.
    programming_style
    writing_xnmt_classes
    save_file_format
-
+   visualization
 
 Indices and tables
 ==================

--- a/docs/visualization.rst
+++ b/docs/visualization.rst
@@ -1,0 +1,34 @@
+.. _sec-writing-classes:
+
+Visualization
+=============
+
+XNMT comes with several visualization tools.
+
+
+Visualization of training progress
+----------------------------------
+
+The training progress can be monitored via Tensorboard. XNMT uses the ``tensorboardX`` package to write logs that can
+be read and visualized via Tensorboard. These logs are written out by default, no configuration is required.
+To run Tensorboard, Tensorflow must be installed first (see Tensorflow home page for further instructions):
+
+.. code-block:: bash
+
+  pip install tensorflow
+  tensorboard --logdir <path/to/base/xnmt/log/dir>
+
+
+Visualization of translation outputs
+------------------------------------
+
+Translation outputs can be analyzed via reporters as defined in ``xnmt/reports.py``. To use reporters, set
+``experiment.exp_global.compute_report = True`` in your config file. Reports can only be used for inference-only
+experiments, i.e. experiments that load a pretrained model and only perform inference but no training.
+The following reporters are available (see API doc for more details):
+
+* ``AttentionReporter``: print attention matrices
+* ``ReferenceDiffReporter``: HTML-visualization of diffs between reference and actual output
+* ``CompareMtReporter``: perform detailed analysis, including computing over- and undergenerated n-grams.
+* ``OOVStatisticsReporter``: compute OOV statistics, useful when using character- or subword models.
+* ``SegmentationReporter``: specialized reporter for the segmentation models.

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -1,3 +1,4 @@
-librosa
+librosa # for audio feature extraction
 sentencepiece>=0.0.6
 docopt
+tensorflow # for tensorboard visualization

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -1,4 +1,0 @@
-librosa # for audio feature extraction
-sentencepiece>=0.0.6
-docopt
-tensorflow # for tensorboard visualization

--- a/requirements-extra/README
+++ b/requirements-extra/README
@@ -1,0 +1,2 @@
+This directory contains requirement files for dependencies that are required when using some specialized XNMT features,
+but not for its core features.

--- a/requirements-extra/audio-feature-extraction.txt
+++ b/requirements-extra/audio-feature-extraction.txt
@@ -1,0 +1,2 @@
+# needed for audio feature extraction via !MelFiltExtractor
+librosa

--- a/requirements-extra/build-doc.txt
+++ b/requirements-extra/build-doc.txt
@@ -1,0 +1,2 @@
+Sphinx
+sphinxcontrib-napoleon

--- a/requirements-extra/ensembling-scripts.txt
+++ b/requirements-extra/ensembling-scripts.txt
@@ -1,0 +1,2 @@
+# needed for some scripts under 'script/code'
+docopt

--- a/requirements-extra/sentencepiece.txt
+++ b/requirements-extra/sentencepiece.txt
@@ -1,0 +1,2 @@
+# Needed when using sentencepiece via !SentencepieceTokenizer or !SentencePieceTextReader
+sentencepiece>=0.0.6

--- a/requirements-extra/tensorboard.txt
+++ b/requirements-extra/tensorboard.txt
@@ -1,0 +1,2 @@
+# for tensorboard visualization; run via 'tensorboard --logdir <path/to/base/xnmt/log/dir>'
+tensorflow

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ numpy
 Unidecode>=1.0.22
 beautifulsoup4
 nltk
+tensorboardX

--- a/xnmt/loss_trackers.py
+++ b/xnmt/loss_trackers.py
@@ -21,8 +21,8 @@ class AccumTimeTracker(object):
 
 class TrainLossTracker(object):
 
-  REPORT_TEMPLATE_SPEED = 'Epoch {epoch:.4f}: {data}_loss/word={loss:.6f} (words={words}, words/sec={words_per_sec:.2f}, time={time})'
-  REPORT_TEMPLATE = 'Epoch {epoch:.4f}: {data}_loss/word={loss:.6f} (words={words}, words/sec={words_per_sec}, time={time})'
+  REPORT_TEMPLATE_SPEED = 'Epoch {epoch:.4f}: {data_name}_loss/word={loss:.6f} (words={words}, words/sec={words_per_sec:.2f}, time={time})'
+  REPORT_TEMPLATE = 'Epoch {epoch:.4f}: {data_name}_loss/word={loss:.6f} (words={words}, words/sec={words_per_sec}, time={time})'
   REPORT_TEMPLATE_ADDITIONAL = '- {loss_name} {loss:5.6f}'
   REPORT_EVERY = 1000
 
@@ -64,24 +64,40 @@ class TrainLossTracker(object):
       fractional_epoch = (self.training_task.training_state.epoch_num - 1) \
                          + self.training_task.training_state.sents_into_epoch / self.training_task.cur_num_sentences()
       accum_time = self.time_tracker.get_and_reset()
-      utils.log_readable_and_structured(
-        TrainLossTracker.REPORT_TEMPLATE_SPEED if accum_time else TrainLossTracker.REPORT_TEMPLATE,
-        {"key": "train_loss", "data": "train",
-         "epoch": fractional_epoch,
-         "loss": self.epoch_loss.sum_factors() / self.epoch_words,
-         "words": self.epoch_words,
-         "words_per_sec": (self.epoch_words - self.last_report_words) / (
-           accum_time) if accum_time else "-",
-         "time": utils.format_time(time.time() - self.start_time)},
-        task_name=self.name)
+      rep_train_loss = self.epoch_loss.sum_factors() / self.epoch_words
+      utils.log_readable_and_tensorboard(
+        template = TrainLossTracker.REPORT_TEMPLATE_SPEED if accum_time else TrainLossTracker.REPORT_TEMPLATE,
+        args = {"loss": rep_train_loss,"words_per_sec": (self.epoch_words - self.last_report_words) / accum_time} \
+                if accum_time else {"loss": rep_train_loss},
+        n_iter = fractional_epoch,
+        time = utils.format_time(time.time() - self.start_time),
+        words = self.epoch_words,
+        data_name = "train",
+        task_name = self.name)
+      # utils.log_readable_and_structured(
+      #   TrainLossTracker.REPORT_TEMPLATE_SPEED if accum_time else TrainLossTracker.REPORT_TEMPLATE,
+      #   {"key": "train_loss", "name": "train",
+      #    "epoch": fractional_epoch,
+      #    "loss": self.epoch_loss.sum_factors() / self.epoch_words,
+      #    "words": self.epoch_words,
+      #    "words_per_sec": (self.epoch_words - self.last_report_words) / (
+      #      accum_time) if accum_time else "-",
+      #    "time": utils.format_time(time.time() - self.start_time)},
+      #   task_name=self.name)
 
       if len(self.epoch_loss) > 1:
         for loss_name, loss_values in self.epoch_loss.items():
-          utils.log_readable_and_structured(TrainLossTracker.REPORT_TEMPLATE_ADDITIONAL,
-                                            {"key": "additional_train_loss",
-                                            "loss_name": loss_name,
-                                            "loss": loss_values / self.epoch_words},
-                                            task_name=self.name)
+          # utils.log_readable_and_structured(TrainLossTracker.REPORT_TEMPLATE_ADDITIONAL,
+          #                                   {"key": "additional_train_loss",
+          #                                   "loss_name": loss_name,
+          #                                   "loss": loss_values / self.epoch_words},
+          #                                   task_name=self.name)
+          utils.log_readable_and_tensorboard(template=TrainLossTracker.REPORT_TEMPLATE_ADDITIONAL,
+                                             args={loss_name: loss_values / self.epoch_words},
+                                             n_iter=fractional_epoch,
+                                             data_name="train",
+                                             task_name=self.name
+                                             )
 
       self.last_report_words = self.epoch_words
       self.last_report_sents_since_start = self.training_task.training_state.sents_since_start
@@ -131,20 +147,39 @@ class DevLossTracker(object):
     self.fractional_epoch = (self.training_task.training_state.epoch_num - 1) \
                             + self.training_task.training_state.sents_into_epoch / self.training_task.cur_num_sentences()
     dev_time = self.time_tracker.get_and_reset()
-    utils.log_readable_and_structured(DevLossTracker.REPORT_TEMPLATE_DEV,
-                                      {"key": "dev_loss",
-                                      "epoch": self.fractional_epoch,
-                                      "score": self.dev_score,
-                                      "time": utils.format_time(this_report_time - self.start_time)
-                                      },
-                                      task_name=self.name)
+    # utils.log_readable_and_structured(DevLossTracker.REPORT_TEMPLATE_DEV,
+    #                                   {"key": "dev_loss",
+    #                                   "epoch": self.fractional_epoch,
+    #                                   "score": self.dev_score,
+    #                                   "time": utils.format_time(this_report_time - self.start_time)
+    #                                   },
+    #                                   task_name=self.name)
+    utils.log_readable_and_tensorboard(template=DevLossTracker.REPORT_TEMPLATE_DEV,
+                                       args={self.dev_score.metric_name(): self.dev_score.value()},
+                                       n_iter=self.fractional_epoch,
+                                       data_name="dev",
+                                       task_name=self.name,
+                                       score=self.dev_score,
+                                       time=utils.format_time(this_report_time - self.start_time))
     for score in self.aux_scores:
-      utils.log_readable_and_structured(DevLossTracker.REPORT_TEMPLATE_DEV_AUX,
-                                        {"key": "auxiliary_score", "epoch": self.fractional_epoch, "score": score},
-                                        task_name=self.name)
-    utils.log_readable_and_structured(DevLossTracker.REPORT_TEMPLATE_TIME_NEEDED,
-                                      {"key": "dev_time_needed", "epoch": self.fractional_epoch,
-                                      "time_needed": utils.format_time(dev_time)},
-                                      task_name=self.name)
+      # utils.log_readable_and_structured(DevLossTracker.REPORT_TEMPLATE_DEV_AUX,
+      #                                   {"key": "auxiliary_score", "epoch": self.fractional_epoch, "score": score},
+      #                                   task_name=self.name)
+      utils.log_readable_and_tensorboard(template=DevLossTracker.REPORT_TEMPLATE_DEV_AUX,
+                                         args={score.metric_name(): score.value()},
+                                         n_iter=self.fractional_epoch,
+                                         data_name="dev",
+                                         task_name=self.name,
+                                         score=score)
+    # utils.log_readable_and_structured(DevLossTracker.REPORT_TEMPLATE_TIME_NEEDED,
+    #                                   {"key": "dev_time_needed", "epoch": self.fractional_epoch,
+    #                                   "time_needed": utils.format_time(dev_time)},
+    #                                   task_name=self.name)
+    utils.log_readable_and_tensorboard(template=DevLossTracker.REPORT_TEMPLATE_TIME_NEEDED,
+                                       args={"evaltime": dev_time},
+                                       n_iter=self.fractional_epoch,
+                                       data_name="dev",
+                                       task_name=self.name,
+                                       time_needed = utils.format_time(dev_time))
     self.aux_scores = []
 

--- a/xnmt/loss_trackers.py
+++ b/xnmt/loss_trackers.py
@@ -82,7 +82,9 @@ class TrainLossTracker(object):
                                              args={loss_name: loss_values / self.epoch_words},
                                              n_iter=fractional_epoch,
                                              data_name="train",
-                                             task_name=self.name
+                                             task_name=self.name,
+                                             loss_name=loss_name,
+                                             loss=loss_values / self.epoch_words,
                                              )
 
       self.last_report_words = self.epoch_words

--- a/xnmt/tee.py
+++ b/xnmt/tee.py
@@ -5,7 +5,7 @@ import tensorboardX
 import yaml
 
 from xnmt.settings import settings
-from xnmt.utils import make_parent_dir
+from xnmt import utils
 import xnmt.git_rev
 
 STD_OUTPUT_LEVELNO = 35
@@ -60,15 +60,15 @@ class TensorboardCustomWriter(object):
   def __init__(self):
     self.out_file_name = None
     self.writer = None
-  def set_out_file(self, out_file_name):
+    self.exp_name = None
+  def set_out_file(self, out_file_name, exp_name):
     self.out_file_name = out_file_name
-    self.writer = tensorboardX.SummaryWriter()
-  def flush(self):
-    self.writer.export_scalars_to_json(self.out_file_name)
+    self.exp_name = exp_name
+    self.writer = tensorboardX.SummaryWriter(log_dir=f"{os.path.dirname(out_file_name)}.tb")
   def unset_out_file(self):
     self.out_file_name = None
-  def add_scalars(self, *args, **kwargs):
-    return self.writer.add_scalars(*args, **kwargs)
+  def add_scalars(self, name, *args, **kwargs):
+    return self.writer.add_scalars(f"{self.exp_name}/{name}", *args, **kwargs)
 
 tensorboard_writer = TensorboardCustomWriter()
 
@@ -83,14 +83,15 @@ def log_preamble(log_line, level=logging.INFO):
   _preamble_content.append(log_line)
   logger.log(level=level, msg=log_line)
 
-def set_out_file(out_file):
+def set_out_file(out_file, exp_name):
   """
   Set the file to log to. Before calling this, logs are only passed to stdout/stderr.
   Args:
     out_file: file name
+    exp_name: name of experiment
   """
   unset_out_file()
-  make_parent_dir(out_file)
+  utils.make_parent_dir(out_file)
   with open(out_file, mode="w") as f_out:
     for line in _preamble_content:
       f_out.write(f"{line}\n")
@@ -104,7 +105,7 @@ def set_out_file(out_file):
   yaml_fh.setFormatter(YamlFormatter())
   yaml_fh.setLevel(logging.DEBUG)
   yaml_logger.addHandler(yaml_fh)
-  tensorboard_writer.set_out_file(f"{out_file}.tb.json")
+  tensorboard_writer.set_out_file(f"{out_file}.tb.json", exp_name=exp_name)
 
 def unset_out_file():
   """

--- a/xnmt/tee.py
+++ b/xnmt/tee.py
@@ -105,7 +105,7 @@ def set_out_file(out_file, exp_name):
   yaml_fh.setFormatter(YamlFormatter())
   yaml_fh.setLevel(logging.DEBUG)
   yaml_logger.addHandler(yaml_fh)
-  tensorboard_writer.set_out_file(f"{out_file}.tb.json", exp_name=exp_name)
+  tensorboard_writer.set_out_file(f"{out_file}.tb", exp_name=exp_name)
 
 def unset_out_file():
   """

--- a/xnmt/tee.py
+++ b/xnmt/tee.py
@@ -64,7 +64,7 @@ class TensorboardCustomWriter(object):
   def set_out_file(self, out_file_name, exp_name):
     self.out_file_name = out_file_name
     self.exp_name = exp_name
-    self.writer = tensorboardX.SummaryWriter(log_dir=f"{out_file_name}.tb")
+    self.writer = tensorboardX.SummaryWriter(log_dir=f"{out_file_name}")
   def unset_out_file(self):
     self.out_file_name = None
   def add_scalars(self, name, *args, **kwargs):

--- a/xnmt/tee.py
+++ b/xnmt/tee.py
@@ -64,7 +64,7 @@ class TensorboardCustomWriter(object):
   def set_out_file(self, out_file_name, exp_name):
     self.out_file_name = out_file_name
     self.exp_name = exp_name
-    self.writer = tensorboardX.SummaryWriter(log_dir=f"{os.path.dirname(out_file_name)}.tb")
+    self.writer = tensorboardX.SummaryWriter(log_dir=f"{out_file_name}.tb")
   def unset_out_file(self):
     self.out_file_name = None
   def add_scalars(self, name, *args, **kwargs):

--- a/xnmt/utils.py
+++ b/xnmt/utils.py
@@ -34,11 +34,6 @@ def format_time(seconds):
   return "{}-{}".format(int(seconds) // 86400,
                         time.strftime("%H:%M:%S", time.gmtime(seconds)))
 
-# def log_readable_and_structured(template, args, task_name=None):
-#   if task_name: args["task_name"] = task_name
-#   logger.info(template.format(**args), extra=args)
-#   yaml_logger.info(args)
-
 def log_readable_and_tensorboard(template, args, n_iter, data_name, task_name=None, **kwargs):
   log_args = dict(args)
   log_args["data_name"] = data_name
@@ -51,7 +46,6 @@ def log_readable_and_tensorboard(template, args, n_iter, data_name, task_name=No
   tensorboard_writer.add_scalars(f"{task_name}/{data_name}" if task_name else data_name,
                                  args,
                                  n_iter)
-  tensorboard_writer.flush()
 
 class RollingStatistic(object):
   """

--- a/xnmt/utils.py
+++ b/xnmt/utils.py
@@ -34,10 +34,24 @@ def format_time(seconds):
   return "{}-{}".format(int(seconds) // 86400,
                         time.strftime("%H:%M:%S", time.gmtime(seconds)))
 
-def log_readable_and_structured(template, args, task_name=None):
-  if task_name: args["task_name"] = task_name
-  logger.info(template.format(**args), extra=args)
-  yaml_logger.info(args)
+# def log_readable_and_structured(template, args, task_name=None):
+#   if task_name: args["task_name"] = task_name
+#   logger.info(template.format(**args), extra=args)
+#   yaml_logger.info(args)
+
+def log_readable_and_tensorboard(template, args, n_iter, data_name, task_name=None, **kwargs):
+  log_args = dict(args)
+  log_args["data_name"] = data_name
+  log_args["epoch"] = n_iter
+  log_args.update(kwargs)
+  if task_name: log_args["task_name"] = task_name
+  logger.info(template.format(**log_args), extra=log_args)
+
+  from xnmt.tee import tensorboard_writer
+  tensorboard_writer.add_scalars(f"{task_name}/{data_name}" if task_name else data_name,
+                                 args,
+                                 n_iter)
+  tensorboard_writer.flush()
 
 class RollingStatistic(object):
   """

--- a/xnmt/xnmt_run_experiments.py
+++ b/xnmt/xnmt_run_experiments.py
@@ -84,7 +84,7 @@ def main(overwrite_args=None):
                        f"or specifying --settings=debug, or changing xnmt.settings.Standard.OVERWRITE_LOG manually)")
         continue
 
-      tee.set_out_file(log_file)
+      tee.set_out_file(log_file, exp_name=experiment_name)
 
       try:
 


### PR DESCRIPTION
This PR uses the tensorboardX package to write out training logs that can be read by tensorboard. We previously wrote out the same information via the structured logger and I've simply replaced using the structured logger here by using the tensorboardX writer. The structured logger still exists but is not used currently. Tensorboard outputs are organized as ```exp_name/train_task_name/[train|dev]/[loss_name]```

Tensorboard outputs are written without further configuration necessary The only thing that has to be done to visualize outputs is to install tensorflow, and run ```tensorboard --logdir [logdir]```.