### PR TITLE
Revert bugfix and add more unit tests

### DIFF
--- a/test/config/cascade.yaml
+++ b/test/config/cascade.yaml
@@ -35,8 +35,8 @@ cascade: !Experiment
     - !SimpleTrainingTask
       kwargs:
         << : *task1
-        src_file: 'examples/LDC94S13A.char'
-        trg_file: 'examples/LDC94S13A.char'
+        src_file: 'examples/data/LDC94S13A.char'
+        trg_file: 'examples/data/LDC94S13A.char'
         model: !DefaultTranslator
           src_embedder: !SimpleWordEmbedder
             emb_dim: 64
@@ -63,8 +63,8 @@ cascade: !Experiment
     - !AccuracyEvalTask
       desc: casc_acc
       eval_metrics: bleu
-      src_file: 'examples/LDC94S13A.h5'
-      ref_file: 'examples/LDC94S13A.words'
+      src_file: 'examples/data/LDC94S13A.h5'
+      ref_file: 'examples/data/LDC94S13A.words'
       hyp_file: '{EXP_DIR}/hyp/{EXP}.eval_casc_hyp'
       model: !CascadeGenerator
         generators:

--- a/test/config/cascade.yaml
+++ b/test/config/cascade.yaml
@@ -1,0 +1,80 @@
+cascade: !Experiment
+  exp_global: !ExpGlobal
+    default_layer_dim: 32
+  train: !SerialMultiTaskTrainingRegimen
+    tasks:
+    - !SimpleTrainingTask
+      kwargs: &task1
+        dev_every: 0
+        run_for_epochs: 1
+        src_file: 'examples/data/LDC94S13A.h5'
+        trg_file: 'examples/data/LDC94S13A.char'
+        model: !DefaultTranslator
+          src_embedder: !NoopEmbedder
+            emb_dim: 40
+          encoder: !BiLSTMSeqTransducer
+            input_dim: 40
+            hidden_dim: 32
+          attender: !MlpAttender
+            _xnmt_id: task1_attender
+            hidden_dim: 128
+          trg_embedder: !SimpleWordEmbedder
+            emb_dim: 64
+            vocab: !Vocab
+              _xnmt_id: char_vocab
+              vocab_file: 'examples/data/char.vocab'
+          decoder: !AutoRegressiveDecoder
+            scorer: !Softmax
+              vocab: !Ref { name: char_vocab }
+            bridge: !CopyBridge {}
+            transform: !AuxNonLinear {}
+          src_reader: !H5Reader
+            transpose: y
+          trg_reader: !PlainTextReader
+            vocab: !Ref { name: char_vocab }
+    - !SimpleTrainingTask
+      kwargs:
+        << : *task1
+        src_file: 'examples/LDC94S13A.char'
+        trg_file: 'examples/LDC94S13A.char'
+        model: !DefaultTranslator
+          src_embedder: !SimpleWordEmbedder
+            emb_dim: 64
+            vocab: !Ref { name: char_vocab }
+          encoder: !BiLSTMSeqTransducer {}
+          attender: !Ref { name: task1_attender }
+          trg_embedder: !SimpleWordEmbedder
+            emb_dim: 64
+            vocab: !Ref { name: char_vocab }
+          decoder: !AutoRegressiveDecoder
+            _xnmt_id: task1_decoder
+            scorer: !Softmax
+              label_smoothing: 0.1
+              vocab: !Ref { name: char_vocab }
+            rnn: !UniLSTMSeqTransducer
+              _xnmt_id: task1_dec_lstm
+              layers: 1
+            transform: !AuxNonLinear {}
+          src_reader: !PlainTextReader
+            vocab: !Ref { name: char_vocab }
+          trg_reader: !PlainTextReader
+            vocab: !Ref { name: char_vocab }
+  evaluate:
+    - !AccuracyEvalTask
+      desc: casc_acc
+      eval_metrics: bleu
+      src_file: 'examples/LDC94S13A.h5'
+      ref_file: 'examples/LDC94S13A.words'
+      hyp_file: '{EXP_DIR}/hyp/{EXP}.eval_casc_hyp'
+      model: !CascadeGenerator
+        generators:
+        - !Ref { path: train.tasks.0.model }
+        - !Ref { path: train.tasks.1.model }
+      inference: !CascadeInference
+        steps:
+        - !AutoRegressiveInference
+              batcher: !InOrderBatcher
+                _xnmt_id: inference_audio_batcher
+        - !AutoRegressiveInference
+              batcher: !InOrderBatcher { batch_size: 1 }
+              post_process: join-char

--- a/test/config/cascade.yaml
+++ b/test/config/cascade.yaml
@@ -67,9 +67,8 @@ cascade: !Experiment
       ref_file: 'examples/data/LDC94S13A.words'
       hyp_file: '{EXP_DIR}/hyp/{EXP}.eval_casc_hyp'
       model: !CascadeGenerator
-        generators:
-        - !Ref { path: train.tasks.0.model }
-        - !Ref { path: train.tasks.1.model }
+        generator1: !Ref { path: train.tasks.0.model }
+        generator2: !Ref { path: train.tasks.1.model }
       inference: !CascadeInference
         steps:
         - !AutoRegressiveInference

--- a/test/config/cascade.yaml
+++ b/test/config/cascade.yaml
@@ -67,8 +67,9 @@ cascade: !Experiment
       ref_file: 'examples/data/LDC94S13A.words'
       hyp_file: '{EXP_DIR}/hyp/{EXP}.eval_casc_hyp'
       model: !CascadeGenerator
-        generator1: !Ref { path: train.tasks.0.model }
-        generator2: !Ref { path: train.tasks.1.model }
+        generators:
+        - !Ref { path: train.tasks.0.model }
+        - !Ref { path: train.tasks.1.model }
       inference: !CascadeInference
         steps:
         - !AutoRegressiveInference

--- a/test/test_persistence.py
+++ b/test/test_persistence.py
@@ -270,6 +270,7 @@ class DummyArgClass2(Serializable):
 class TestSaving(unittest.TestCase):
   def setUp(self):
     events.clear()
+    xnmt.resolved_serialize_params = {}
     yaml.add_representer(DummyArgClass, xnmt.init_representer)
     yaml.add_representer(DummyArgClass2, xnmt.init_representer)
     self.out_dir = os.path.join("test", "tmp")
@@ -319,6 +320,22 @@ class TestSaving(unittest.TestCase):
     preloaded = YamlPreloader.preload_obj(root=test_obj,exp_name="exp1",exp_dir=self.out_dir)
     initalized = initialize_if_needed(preloaded)
     save_to_file(self.model_file, initalized)
+
+  def test_double_ref(self):
+    test_obj = yaml.load("""
+                         a: !DummyArgClass
+                           arg1: !DummyArgClass2
+                             _xnmt_id: id1
+                             v: some_val
+                           arg2:
+                             - !Ref { name: id1 }
+                             - !Ref { name: id1 }
+                         """)
+    preloaded = YamlPreloader.preload_obj(root=test_obj,exp_name="exp1",exp_dir=self.out_dir)
+    initalized = initialize_if_needed(preloaded)
+    save_to_file(self.model_file, initalized)
+
+
 
   def tearDown(self):
     try:

--- a/test/test_persistence.py
+++ b/test/test_persistence.py
@@ -13,42 +13,42 @@ class TestPath(unittest.TestCase):
     pass
 
   def test_init(self):
-    self.assertTrue(type(persistence.persistence.Path(""))==persistence.persistence.Path)
-    self.assertTrue(type(persistence.persistence.Path(".."))==persistence.persistence.Path)
-    self.assertTrue(type(persistence.persistence.Path(".2"))==persistence.persistence.Path)
-    self.assertTrue(type(persistence.persistence.Path("one.2"))==persistence.persistence.Path)
+    self.assertTrue(type(persistence.Path(""))==persistence.Path)
+    self.assertTrue(type(persistence.Path(".."))==persistence.Path)
+    self.assertTrue(type(persistence.Path(".2"))==persistence.Path)
+    self.assertTrue(type(persistence.Path("one.2"))==persistence.Path)
     with self.assertRaises(ValueError):
-      persistence.persistence.Path(".one.")
-      persistence.persistence.Path("one..2")
+      persistence.Path(".one.")
+      persistence.Path("one..2")
   def test_str(self):
-    self.assertEqual(str(persistence.persistence.Path("one.2")), "one.2")
-    self.assertEqual(str(persistence.persistence.Path("")), "")
+    self.assertEqual(str(persistence.Path("one.2")), "one.2")
+    self.assertEqual(str(persistence.Path("")), "")
   def test_set(self):
-    s = {persistence.persistence.Path("one.2"), persistence.persistence.Path("one.1.3"), persistence.persistence.Path("one.1.3")}
-    self.assertIn(persistence.persistence.Path("one.2"), s)
+    s = {persistence.Path("one.2"), persistence.Path("one.1.3"), persistence.Path("one.1.3")}
+    self.assertIn(persistence.Path("one.2"), s)
     self.assertEqual(len(s), 2)
   def test_append(self):
-    self.assertEqual(str(persistence.persistence.Path("one").append("2")), "one.2")
-    self.assertEqual(str(persistence.persistence.Path("").append("2")), "2")
-    self.assertEqual(str(persistence.persistence.Path(".").append("2")), ".2")
-    self.assertEqual(str(persistence.persistence.Path(".1.2").append("2")), ".1.2.2")
+    self.assertEqual(str(persistence.Path("one").append("2")), "one.2")
+    self.assertEqual(str(persistence.Path("").append("2")), "2")
+    self.assertEqual(str(persistence.Path(".").append("2")), ".2")
+    self.assertEqual(str(persistence.Path(".1.2").append("2")), ".1.2.2")
     with self.assertRaises(ValueError):
-      persistence.persistence.Path("one").append("")
+      persistence.Path("one").append("")
     with self.assertRaises(ValueError):
-      persistence.persistence.Path("one").append(".")
+      persistence.Path("one").append(".")
     with self.assertRaises(ValueError):
-      persistence.persistence.Path("one").append("two.3")
+      persistence.Path("one").append("two.3")
   def test_add_path(self):
-    self.assertEqual(str(persistence.persistence.Path("one").add_path(persistence.persistence.Path("2"))), "one.2")
-    self.assertEqual(str(persistence.persistence.Path("one").add_path(persistence.persistence.Path("2.3"))), "one.2.3")
-    self.assertEqual(str(persistence.persistence.Path("").add_path(persistence.persistence.Path("2.3"))), "2.3")
-    self.assertEqual(str(persistence.persistence.Path("one.2").add_path(persistence.persistence.Path(""))), "one.2")
-    self.assertEqual(str(persistence.persistence.Path("").add_path(persistence.persistence.Path(""))), "")
-    self.assertEqual(str(persistence.persistence.Path(".").add_path(persistence.persistence.Path(""))), ".")
-    self.assertEqual(str(persistence.persistence.Path(".").add_path(persistence.persistence.Path("one.two"))), ".one.two")
-    self.assertEqual(str(persistence.persistence.Path(".xy").add_path(persistence.persistence.Path("one.two"))), ".xy.one.two")
+    self.assertEqual(str(persistence.Path("one").add_path(persistence.Path("2"))), "one.2")
+    self.assertEqual(str(persistence.Path("one").add_path(persistence.Path("2.3"))), "one.2.3")
+    self.assertEqual(str(persistence.Path("").add_path(persistence.Path("2.3"))), "2.3")
+    self.assertEqual(str(persistence.Path("one.2").add_path(persistence.Path(""))), "one.2")
+    self.assertEqual(str(persistence.Path("").add_path(persistence.Path(""))), "")
+    self.assertEqual(str(persistence.Path(".").add_path(persistence.Path(""))), ".")
+    self.assertEqual(str(persistence.Path(".").add_path(persistence.Path("one.two"))), ".one.two")
+    self.assertEqual(str(persistence.Path(".xy").add_path(persistence.Path("one.two"))), ".xy.one.two")
     with self.assertRaises(NotImplementedError):
-      persistence.persistence.Path("one").add_path(persistence.persistence.Path(".2.3"))
+      persistence.Path("one").add_path(persistence.Path(".2.3"))
   def test_get_absolute(self):
     self.assertEqual(persistence.Path(".").get_absolute(persistence.Path("1.2")), persistence.Path("1.2"))
     self.assertEqual(persistence.Path(".x.y").get_absolute(persistence.Path("1.2")), persistence.Path("1.2.x.y"))
@@ -319,6 +319,7 @@ class TestSaving(unittest.TestCase):
     initalized = persistence.initialize_if_needed(preloaded)
     persistence.save_to_file(self.model_file, initalized)
 
+  @unittest.expectedFailure # TODO: need to fix resolving references inside lists
   def test_double_ref(self):
     test_obj = yaml.load("""
                          a: !DummyArgClass

--- a/test/test_persistence.py
+++ b/test/test_persistence.py
@@ -5,9 +5,7 @@ import shutil
 import yaml
 
 import xnmt
-from xnmt import events, param_collections, utils
-from xnmt.persistence import Path, YamlPreloader, Serializable, serializable_init, bare, initialize_if_needed,\
-  save_to_file
+from xnmt import events, param_collections, persistence, utils
 
 class TestPath(unittest.TestCase):
 
@@ -15,117 +13,117 @@ class TestPath(unittest.TestCase):
     pass
 
   def test_init(self):
-    self.assertTrue(type(Path(""))==Path)
-    self.assertTrue(type(Path(".."))==Path)
-    self.assertTrue(type(Path(".2"))==Path)
-    self.assertTrue(type(Path("one.2"))==Path)
+    self.assertTrue(type(persistence.persistence.Path(""))==persistence.persistence.Path)
+    self.assertTrue(type(persistence.persistence.Path(".."))==persistence.persistence.Path)
+    self.assertTrue(type(persistence.persistence.Path(".2"))==persistence.persistence.Path)
+    self.assertTrue(type(persistence.persistence.Path("one.2"))==persistence.persistence.Path)
     with self.assertRaises(ValueError):
-      Path(".one.")
-      Path("one..2")
+      persistence.persistence.Path(".one.")
+      persistence.persistence.Path("one..2")
   def test_str(self):
-    self.assertEqual(str(Path("one.2")), "one.2")
-    self.assertEqual(str(Path("")), "")
+    self.assertEqual(str(persistence.persistence.Path("one.2")), "one.2")
+    self.assertEqual(str(persistence.persistence.Path("")), "")
   def test_set(self):
-    s = {Path("one.2"), Path("one.1.3"), Path("one.1.3")}
-    self.assertIn(Path("one.2"), s)
+    s = {persistence.persistence.Path("one.2"), persistence.persistence.Path("one.1.3"), persistence.persistence.Path("one.1.3")}
+    self.assertIn(persistence.persistence.Path("one.2"), s)
     self.assertEqual(len(s), 2)
   def test_append(self):
-    self.assertEqual(str(Path("one").append("2")), "one.2")
-    self.assertEqual(str(Path("").append("2")), "2")
-    self.assertEqual(str(Path(".").append("2")), ".2")
-    self.assertEqual(str(Path(".1.2").append("2")), ".1.2.2")
+    self.assertEqual(str(persistence.persistence.Path("one").append("2")), "one.2")
+    self.assertEqual(str(persistence.persistence.Path("").append("2")), "2")
+    self.assertEqual(str(persistence.persistence.Path(".").append("2")), ".2")
+    self.assertEqual(str(persistence.persistence.Path(".1.2").append("2")), ".1.2.2")
     with self.assertRaises(ValueError):
-      Path("one").append("")
+      persistence.persistence.Path("one").append("")
     with self.assertRaises(ValueError):
-      Path("one").append(".")
+      persistence.persistence.Path("one").append(".")
     with self.assertRaises(ValueError):
-      Path("one").append("two.3")
+      persistence.persistence.Path("one").append("two.3")
   def test_add_path(self):
-    self.assertEqual(str(Path("one").add_path(Path("2"))), "one.2")
-    self.assertEqual(str(Path("one").add_path(Path("2.3"))), "one.2.3")
-    self.assertEqual(str(Path("").add_path(Path("2.3"))), "2.3")
-    self.assertEqual(str(Path("one.2").add_path(Path(""))), "one.2")
-    self.assertEqual(str(Path("").add_path(Path(""))), "")
-    self.assertEqual(str(Path(".").add_path(Path(""))), ".")
-    self.assertEqual(str(Path(".").add_path(Path("one.two"))), ".one.two")
-    self.assertEqual(str(Path(".xy").add_path(Path("one.two"))), ".xy.one.two")
+    self.assertEqual(str(persistence.persistence.Path("one").add_path(persistence.persistence.Path("2"))), "one.2")
+    self.assertEqual(str(persistence.persistence.Path("one").add_path(persistence.persistence.Path("2.3"))), "one.2.3")
+    self.assertEqual(str(persistence.persistence.Path("").add_path(persistence.persistence.Path("2.3"))), "2.3")
+    self.assertEqual(str(persistence.persistence.Path("one.2").add_path(persistence.persistence.Path(""))), "one.2")
+    self.assertEqual(str(persistence.persistence.Path("").add_path(persistence.persistence.Path(""))), "")
+    self.assertEqual(str(persistence.persistence.Path(".").add_path(persistence.persistence.Path(""))), ".")
+    self.assertEqual(str(persistence.persistence.Path(".").add_path(persistence.persistence.Path("one.two"))), ".one.two")
+    self.assertEqual(str(persistence.persistence.Path(".xy").add_path(persistence.persistence.Path("one.two"))), ".xy.one.two")
     with self.assertRaises(NotImplementedError):
-      Path("one").add_path(Path(".2.3"))
+      persistence.persistence.Path("one").add_path(persistence.persistence.Path(".2.3"))
   def test_get_absolute(self):
-    self.assertEqual(Path(".").get_absolute(Path("1.2")), Path("1.2"))
-    self.assertEqual(Path(".x.y").get_absolute(Path("1.2")), Path("1.2.x.y"))
-    self.assertEqual(Path("..x.y").get_absolute(Path("1.2")), Path("1.x.y"))
-    self.assertEqual(Path("...x.y").get_absolute(Path("1.2")), Path("x.y"))
+    self.assertEqual(persistence.Path(".").get_absolute(persistence.Path("1.2")), persistence.Path("1.2"))
+    self.assertEqual(persistence.Path(".x.y").get_absolute(persistence.Path("1.2")), persistence.Path("1.2.x.y"))
+    self.assertEqual(persistence.Path("..x.y").get_absolute(persistence.Path("1.2")), persistence.Path("1.x.y"))
+    self.assertEqual(persistence.Path("...x.y").get_absolute(persistence.Path("1.2")), persistence.Path("x.y"))
     with self.assertRaises(ValueError):
-      Path("....x.y").get_absolute(Path("1.2"))
+      persistence.Path("....x.y").get_absolute(persistence.Path("1.2"))
   def test_descend_one(self):
-    self.assertEqual(str(Path("one.2.3").descend_one()), "2.3")
-    self.assertEqual(str(Path("3").descend_one()), "")
+    self.assertEqual(str(persistence.Path("one.2.3").descend_one()), "2.3")
+    self.assertEqual(str(persistence.Path("3").descend_one()), "")
     with self.assertRaises(ValueError):
-      Path("").descend_one()
+      persistence.Path("").descend_one()
     with self.assertRaises(ValueError):
-      Path(".one.2").descend_one()
+      persistence.Path(".one.2").descend_one()
   def test_len(self):
-    self.assertEqual(len(Path("")), 0)
-    self.assertEqual(len(Path("one")), 1)
-    self.assertEqual(len(Path("one.2.3")), 3)
+    self.assertEqual(len(persistence.Path("")), 0)
+    self.assertEqual(len(persistence.Path("one")), 1)
+    self.assertEqual(len(persistence.Path("one.2.3")), 3)
     with self.assertRaises(ValueError):
-      len(Path(".one"))
-      len(Path("."))
+      len(persistence.Path(".one"))
+      len(persistence.Path("."))
   def test_get_item(self):
-    self.assertEqual(Path("one")[0], "one")
-    self.assertEqual(Path("one.2.3")[0], "one")
-    self.assertEqual(Path("one.2.3")[2], "3")
-    self.assertEqual(Path("one.2.3")[-1], "3")
+    self.assertEqual(persistence.Path("one")[0], "one")
+    self.assertEqual(persistence.Path("one.2.3")[0], "one")
+    self.assertEqual(persistence.Path("one.2.3")[2], "3")
+    self.assertEqual(persistence.Path("one.2.3")[-1], "3")
     with self.assertRaises(ValueError):
-      Path(".one.2.3")[-1]
+      persistence.Path(".one.2.3")[-1]
   def test_get_item_slice(self):
-    self.assertEqual(str(Path("one")[0:1]), "one")
-    self.assertEqual(str(Path("one.2.3")[1:3]), "2.3")
-    self.assertEqual(str(Path("one.2.3")[0:-1]), "one.2")
-    self.assertEqual(str(Path("one.2.3")[-1:]), "3")
+    self.assertEqual(str(persistence.Path("one")[0:1]), "one")
+    self.assertEqual(str(persistence.Path("one.2.3")[1:3]), "2.3")
+    self.assertEqual(str(persistence.Path("one.2.3")[0:-1]), "one.2")
+    self.assertEqual(str(persistence.Path("one.2.3")[-1:]), "3")
     with self.assertRaises(ValueError):
-      Path(".one.2.3")[0:1:-1]
+      persistence.Path(".one.2.3")[0:1:-1]
   def test_parent(self):
-    self.assertEqual(Path("one").parent(), Path(""))
-    self.assertEqual(Path("one.two.three").parent(), Path("one.two"))
-    self.assertEqual(Path(".one").parent(), Path("."))
+    self.assertEqual(persistence.Path("one").parent(), persistence.Path(""))
+    self.assertEqual(persistence.Path("one.two.three").parent(), persistence.Path("one.two"))
+    self.assertEqual(persistence.Path(".one").parent(), persistence.Path("."))
     with self.assertRaises(ValueError):
-      Path(".").parent()
+      persistence.Path(".").parent()
     with self.assertRaises(ValueError):
-      Path("").parent()
+      persistence.Path("").parent()
   def test_eq(self):
-    self.assertEqual(Path(""), Path(""))
-    self.assertEqual(Path(".."), Path(".."))
-    self.assertEqual(Path("one.2"), Path("one.2"))
-    self.assertEqual(Path("one.2"), Path("one.2.3").parent())
-    self.assertNotEqual(Path("one.2"), Path("one.2.3"))
-    self.assertNotEqual(Path(""), Path("."))
+    self.assertEqual(persistence.Path(""), persistence.Path(""))
+    self.assertEqual(persistence.Path(".."), persistence.Path(".."))
+    self.assertEqual(persistence.Path("one.2"), persistence.Path("one.2"))
+    self.assertEqual(persistence.Path("one.2"), persistence.Path("one.2.3").parent())
+    self.assertNotEqual(persistence.Path("one.2"), persistence.Path("one.2.3"))
+    self.assertNotEqual(persistence.Path(""), persistence.Path("."))
   def test_ancestors(self):
-    self.assertEqual(Path("").ancestors(), {Path("")})
-    self.assertEqual(Path("a").ancestors(), {Path(""), Path("a")})
-    self.assertEqual(Path("one.two.three").ancestors(), {Path(""), Path("one"), Path("one.two"), Path("one.two.three")})
+    self.assertEqual(persistence.Path("").ancestors(), {persistence.Path("")})
+    self.assertEqual(persistence.Path("a").ancestors(), {persistence.Path(""), persistence.Path("a")})
+    self.assertEqual(persistence.Path("one.two.three").ancestors(), {persistence.Path(""), persistence.Path("one"), persistence.Path("one.two"), persistence.Path("one.two.three")})
 
-class DummyClass(Serializable):
+class DummyClass(persistence.Serializable):
   yaml_tag = "!DummyClass"
-  @serializable_init
+  @persistence.serializable_init
   def __init__(self, arg1, arg2="{V2}", arg3="{V3}"):
     self.arg1 = arg1
     self.arg2 = arg2
     self.arg3 = arg3
-class DummyClass2(Serializable):
+class DummyClass2(persistence.Serializable):
   yaml_tag = "!DummyClass2"
-  @serializable_init
-  def __init__(self, arg1=bare(DummyClass)):
+  @persistence.serializable_init
+  def __init__(self, arg1=persistence.bare(DummyClass)):
     self.arg1 = arg1
-class DummyClass3(Serializable):
+class DummyClass3(persistence.Serializable):
   yaml_tag = "!DummyClass3"
-  @serializable_init
-  def __init__(self, arg1=bare(DummyClass2)):
+  @persistence.serializable_init
+  def __init__(self, arg1=persistence.bare(DummyClass2)):
     self.arg1 = arg1
-class DummyClassForgotBare(Serializable):
+class DummyClassForgotBare(persistence.Serializable):
   yaml_tag = "!DummyClassForgotBare"
-  @serializable_init
+  @persistence.serializable_init
   def __init__(self, arg1=DummyClass("")):
     self.arg1 = arg1
 
@@ -143,7 +141,7 @@ class TestPreloader(unittest.TestCase):
           "exp10": DummyClass("")
         },
         f_out)
-    self.assertListEqual(YamlPreloader.experiment_names_from_file(f"{self.out_dir}/tmp.yaml"),
+    self.assertListEqual(persistence.YamlPreloader.experiment_names_from_file(f"{self.out_dir}/tmp.yaml"),
                          ["exp1", "exp10", "exp2"])
 
   def test_inconsistent_loadserialized(self):
@@ -155,7 +153,7 @@ class TestPreloader(unittest.TestCase):
       bad_arg: 1
     """)
     with self.assertRaises(ValueError):
-      YamlPreloader.preload_obj(test_obj, "SOME_EXP_NAME", "SOME_EXP_DIR")
+      persistence.YamlPreloader.preload_obj(test_obj, "SOME_EXP_NAME", "SOME_EXP_DIR")
   def test_inconsistent_loadserialized2(self):
     with open(f"{self.out_dir}/tmp1.yaml", "w") as f_out:
       yaml.dump(DummyClass(arg1="v1"), f_out)
@@ -167,7 +165,7 @@ class TestPreloader(unittest.TestCase):
       - val: b
     """)
     with self.assertRaises(ValueError):
-      YamlPreloader.preload_obj(test_obj, "SOME_EXP_NAME", "SOME_EXP_DIR")
+      persistence.YamlPreloader.preload_obj(test_obj, "SOME_EXP_NAME", "SOME_EXP_DIR")
 
   def test_placeholder_loadserialized(self):
     with open(f"{self.out_dir}/tmp1.yaml", "w") as f_out:
@@ -176,13 +174,13 @@ class TestPreloader(unittest.TestCase):
     a: !LoadSerialized
       filename: '{{EXP_DIR}}/{{EXP}}.yaml'
     """)
-    YamlPreloader.preload_obj(test_obj, exp_name = "tmp1", exp_dir=self.out_dir)
+    persistence.YamlPreloader.preload_obj(test_obj, exp_name = "tmp1", exp_dir=self.out_dir)
 
   def test_load_referenced_serialized_top(self):
     with open(f"{self.out_dir}/tmp1.yaml", "w") as f_out:
       yaml.dump(DummyClass(arg1="v1"), f_out)
     test_obj = yaml.load(f"!LoadSerialized {{ filename: {self.out_dir}/tmp1.yaml }}")
-    loaded_obj = YamlPreloader._load_serialized(test_obj)
+    loaded_obj = persistence.YamlPreloader._load_serialized(test_obj)
     self.assertIsInstance(loaded_obj, DummyClass)
     self.assertEqual(loaded_obj.arg1, "v1")
 
@@ -198,7 +196,7 @@ class TestPreloader(unittest.TestCase):
         val: !LoadSerialized
               filename: {self.out_dir}/tmp1.yaml
     """)
-    loaded_obj = YamlPreloader._load_serialized(test_obj)
+    loaded_obj = persistence.YamlPreloader._load_serialized(test_obj)
     self.assertIsInstance(loaded_obj["b"], DummyClass)
     self.assertIsInstance(loaded_obj["b"].arg1, DummyClass)
 
@@ -209,7 +207,7 @@ class TestPreloader(unittest.TestCase):
         arg1: 1
         other_arg: 2
     """)
-    YamlPreloader._resolve_kwargs(test_obj)
+    persistence.YamlPreloader._resolve_kwargs(test_obj)
     self.assertFalse(hasattr(test_obj, "kwargs"))
     self.assertFalse(hasattr(test_obj, "arg2"))
     self.assertEqual(getattr(test_obj, "arg1", None), 1)
@@ -221,7 +219,7 @@ class TestPreloader(unittest.TestCase):
                            arg1: !DummyClass2 {}
                          b: !DummyClass3 {}
                          """)
-    YamlPreloader._resolve_bare_default_args(test_obj)
+    persistence.YamlPreloader._resolve_bare_default_args(test_obj)
     self.assertIsInstance(test_obj["a"].arg1.arg1, DummyClass)
     self.assertIsInstance(test_obj["b"].arg1, DummyClass2)
     self.assertIsInstance(test_obj["b"].arg1.arg1, DummyClass)
@@ -231,7 +229,7 @@ class TestPreloader(unittest.TestCase):
                          a: !DummyClassForgotBare {}
                          """)
     with self.assertRaises(ValueError):
-      YamlPreloader._resolve_bare_default_args(test_obj)
+      persistence.YamlPreloader._resolve_bare_default_args(test_obj)
 
   def test_format_strings(self):
     test_obj = yaml.load("""
@@ -244,7 +242,7 @@ class TestPreloader(unittest.TestCase):
                          c: '{V1}/bla'
                          d: ['bla', 'bla.{V2}']
                          """)
-    YamlPreloader._format_strings(test_obj, {"V1":"val1", "V2":"val2"})
+    persistence.YamlPreloader._format_strings(test_obj, {"V1":"val1", "V2":"val2"})
     self.assertEqual(test_obj["a"].arg1, "val1")
     self.assertEqual(test_obj["a"].other_arg, 2)
     self.assertEqual(test_obj["a"].arg2, "val2")
@@ -256,14 +254,14 @@ class TestPreloader(unittest.TestCase):
     self.assertEqual(test_obj["c"], "val1/bla")
     self.assertListEqual(test_obj["d"], ["bla", "bla.val2"])
 
-class DummyArgClass(Serializable):
+class DummyArgClass(persistence.Serializable):
   yaml_tag = "!DummyArgClass"
-  @serializable_init
+  @persistence.serializable_init
   def __init__(self, arg1, arg2):
     pass # arg1 and arg2 are purposefully not kept
-class DummyArgClass2(Serializable):
+class DummyArgClass2(persistence.Serializable):
   yaml_tag = "!DummyArgClass2"
-  @serializable_init
+  @persistence.serializable_init
   def __init__(self, v):
     self.v = v
 
@@ -287,9 +285,9 @@ class TestSaving(unittest.TestCase):
                              v: some_val
                            arg2: !Ref { name: id1 }
                          """)
-    preloaded = YamlPreloader.preload_obj(root=test_obj,exp_name="exp1",exp_dir=self.out_dir)
-    initalized = initialize_if_needed(preloaded)
-    save_to_file(self.model_file, initalized)
+    preloaded = persistence.YamlPreloader.preload_obj(root=test_obj,exp_name="exp1",exp_dir=self.out_dir)
+    initalized = persistence.initialize_if_needed(preloaded)
+    persistence.save_to_file(self.model_file, initalized)
 
   def test_mid(self):
     test_obj = yaml.load("""
@@ -301,9 +299,9 @@ class TestSaving(unittest.TestCase):
                            arg2: !DummyArgClass2
                              v: !Ref { name: id1 }
                          """)
-    preloaded = YamlPreloader.preload_obj(root=test_obj,exp_name="exp1",exp_dir=self.out_dir)
-    initalized = initialize_if_needed(preloaded)
-    save_to_file(self.model_file, initalized)
+    preloaded = persistence.YamlPreloader.preload_obj(root=test_obj,exp_name="exp1",exp_dir=self.out_dir)
+    initalized = persistence.initialize_if_needed(preloaded)
+    persistence.save_to_file(self.model_file, initalized)
 
   def test_deep(self):
     test_obj = yaml.load("""
@@ -317,9 +315,9 @@ class TestSaving(unittest.TestCase):
                              v: !DummyArgClass2
                                v: !Ref { name: id1 }
                          """)
-    preloaded = YamlPreloader.preload_obj(root=test_obj,exp_name="exp1",exp_dir=self.out_dir)
-    initalized = initialize_if_needed(preloaded)
-    save_to_file(self.model_file, initalized)
+    preloaded = persistence.YamlPreloader.preload_obj(root=test_obj,exp_name="exp1",exp_dir=self.out_dir)
+    initalized = persistence.initialize_if_needed(preloaded)
+    persistence.save_to_file(self.model_file, initalized)
 
   def test_double_ref(self):
     test_obj = yaml.load("""
@@ -331,9 +329,9 @@ class TestSaving(unittest.TestCase):
                              - !Ref { name: id1 }
                              - !Ref { name: id1 }
                          """)
-    preloaded = YamlPreloader.preload_obj(root=test_obj,exp_name="exp1",exp_dir=self.out_dir)
-    initalized = initialize_if_needed(preloaded)
-    save_to_file(self.model_file, initalized)
+    preloaded = persistence.YamlPreloader.preload_obj(root=test_obj,exp_name="exp1",exp_dir=self.out_dir)
+    initalized = persistence.initialize_if_needed(preloaded)
+    persistence.save_to_file(self.model_file, initalized)
 
 
 
@@ -343,6 +341,37 @@ class TestSaving(unittest.TestCase):
         shutil.rmtree(os.path.join("test","tmp"))
     except:
       pass
+
+class TestReferences(unittest.TestCase):
+  def setUp(self):
+    events.clear()
+    xnmt.resolved_serialize_params = {}
+    yaml.add_representer(DummyArgClass, xnmt.init_representer)
+    yaml.add_representer(DummyArgClass2, xnmt.init_representer)
+    self.out_dir = os.path.join("test", "tmp")
+    utils.make_parent_dir(os.path.join(self.out_dir, "asdf"))
+    self.model_file = os.path.join(self.out_dir, "saved.mod")
+    param_collections.ParamManager.init_param_col()
+    param_collections.ParamManager.param_col.model_file = self.model_file
+
+  def test_simple_reference(self):
+    test_obj = yaml.load("""
+                         !DummyArgClass
+                         arg1: !DummyArgClass
+                           arg1: !DummyArgClass2 { v: some_val }
+                           arg2: !DummyArgClass2 { v: some_other_val }
+                         arg2: !Ref { path: arg1 }
+                         """)
+    preloaded = persistence.YamlPreloader.preload_obj(root=test_obj,exp_name="exp1",exp_dir=self.out_dir)
+    initialized = persistence.initialize_if_needed(preloaded)
+    dump = persistence._dump(initialized)
+    reloaded = yaml.load(dump)
+    if isinstance(reloaded.arg1, persistence.Ref):
+      reloaded.arg1, reloaded.arg2 = reloaded.arg2, reloaded.arg1
+    self.assertIsInstance(reloaded.arg1, DummyArgClass)
+    self.assertIsInstance(reloaded.arg2, persistence.Ref)
+    self.assertIsInstance(reloaded.arg1.arg1, DummyArgClass2)
+    self.assertIsInstance(reloaded.arg1.arg2, DummyArgClass2)
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_persistence.py
+++ b/test/test_persistence.py
@@ -289,6 +289,7 @@ class TestSaving(unittest.TestCase):
     initalized = persistence.initialize_if_needed(preloaded)
     persistence.save_to_file(self.model_file, initalized)
 
+  @unittest.expectedFailure # TODO: need to fix case of serializable not storing its arguments as object members
   def test_mid(self):
     test_obj = yaml.load("""
                          a: !DummyArgClass
@@ -303,6 +304,7 @@ class TestSaving(unittest.TestCase):
     initalized = persistence.initialize_if_needed(preloaded)
     persistence.save_to_file(self.model_file, initalized)
 
+  @unittest.expectedFailure # TODO: need to fix case of serializable not storing its arguments as object members
   def test_deep(self):
     test_obj = yaml.load("""
                          a: !DummyArgClass
@@ -319,7 +321,7 @@ class TestSaving(unittest.TestCase):
     initalized = persistence.initialize_if_needed(preloaded)
     persistence.save_to_file(self.model_file, initalized)
 
-  @unittest.expectedFailure # TODO: need to fix resolving references inside lists
+  @unittest.expectedFailure # TODO: need to fix case of serializable not storing its arguments as object members
   def test_double_ref(self):
     test_obj = yaml.load("""
                          a: !DummyArgClass

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -13,6 +13,9 @@ class TestRunningConfig(unittest.TestCase):
   def test_assemble(self):
     run.main(["test/config/assemble.yaml"])
 
+  def test_cascade(self):
+    run.main(["test/config/cascade.yaml"])
+
   def test_classifier(self):
     run.main(["test/config/classifier.yaml"])
 

--- a/xnmt/models/base.py
+++ b/xnmt/models/base.py
@@ -108,7 +108,7 @@ class GeneratorModel(object):
 
 class CascadeGenerator(GeneratorModel, Serializable):
   """
-  A cascade that chains several generator models.
+  A cascade that chains two generator models.
 
   This generator does not support calling ``generate()`` directly. Instead, it's sub-generators should be accessed
   and used to generate outputs one by one.
@@ -119,9 +119,13 @@ class CascadeGenerator(GeneratorModel, Serializable):
   yaml_tag = '!CascadeGenerator'
 
   @serializable_init
-  def __init__(self, generators: Sequence[GeneratorModel]) -> None:
-    super().__init__(src_reader = generators[0].src_reader, trg_reader = generators[-1].trg_reader)
-    self.generators = generators
+  def __init__(self, generator1: GeneratorModel, generator2: GeneratorModel) -> None:
+    super().__init__(src_reader = generator1.src_reader, trg_reader = generator2.trg_reader)
+    self.generators = [generator1, generator2]
+  # TODO: not supported with serialization, but should use arbitrary number of sub-models like so:
+  # def __init__(self, generators: Sequence[GeneratorModel]) -> None:
+  #   super().__init__(src_reader = generators[0].src_reader, trg_reader = generators[-1].trg_reader)
+  #   self.generators = generators
 
   def generate(self, *args, **kwargs):
     raise ValueError("cannot call CascadeGenerator.generate() directly; access the sub-generators instead.")

--- a/xnmt/models/base.py
+++ b/xnmt/models/base.py
@@ -108,7 +108,7 @@ class GeneratorModel(object):
 
 class CascadeGenerator(GeneratorModel, Serializable):
   """
-  A cascade that chains two generator models.
+  A cascade that chains several generator models.
 
   This generator does not support calling ``generate()`` directly. Instead, it's sub-generators should be accessed
   and used to generate outputs one by one.
@@ -119,13 +119,9 @@ class CascadeGenerator(GeneratorModel, Serializable):
   yaml_tag = '!CascadeGenerator'
 
   @serializable_init
-  def __init__(self, generator1: GeneratorModel, generator2: GeneratorModel) -> None:
-    super().__init__(src_reader = generator1.src_reader, trg_reader = generator2.trg_reader)
-    self.generators = [generator1, generator2]
-  # TODO: not supported with serialization, but should use arbitrary number of sub-models like so:
-  # def __init__(self, generators: Sequence[GeneratorModel]) -> None:
-  #   super().__init__(src_reader = generators[0].src_reader, trg_reader = generators[-1].trg_reader)
-  #   self.generators = generators
+  def __init__(self, generators: Sequence[GeneratorModel]) -> None:
+    super().__init__(src_reader = generators[0].src_reader, trg_reader = generators[-1].trg_reader)
+    self.generators = generators
 
   def generate(self, *args, **kwargs):
     raise ValueError("cannot call CascadeGenerator.generate() directly; access the sub-generators instead.")

--- a/xnmt/persistence.py
+++ b/xnmt/persistence.py
@@ -544,9 +544,9 @@ def _get_child_dict(node, name):
 
 @_get_child.register(Serializable)
 def _get_child_serializable(node, name):
-  if hasattr(node, "serialize_params"):
-    return _get_child(node.serialize_params, name)
-  else:
+  # if hasattr(node, "serialize_params"):
+  #   return _get_child(node.serialize_params, name)
+  # else:
     if not hasattr(node, name):
       raise PathError(f"{node} has no child named {name}")
     return getattr(node, name)
@@ -1358,7 +1358,7 @@ def _resolve_serialize_refs(root):
               src_node_parent = _get_descendant(root, path_src.parent())
               src_node_parent_serialize_params = xnmt.resolved_serialize_params[id(src_node_parent)]
               _set_descendant(src_node_parent_serialize_params, Path(path_src[-1]), ref)
-              if isinstance(src_node_parent, (collections.abc.MutableMapping, collections.abc.Sequence)):
+              if isinstance(src_node_parent, (collections.abc.MutableMapping, collections.abc.MutableSequence)):
                 assert isinstance(_get_descendant(root, path_src.parent().parent()), Serializable), \
                   "resolving references inside nested lists/dicts is not yet implemented"
                 src_node_grandparent = _get_descendant(root, path_src.parent().parent())

--- a/xnmt/persistence.py
+++ b/xnmt/persistence.py
@@ -270,9 +270,12 @@ class Ref(Serializable):
     """Return name, or ``None`` if this is not a named reference"""
     return getattr(self, "name", None)
 
-  def get_path(self) -> 'Path':
+  def get_path(self) -> Optional['Path']:
     """Return path, or ``None`` if this is a named reference"""
-    return getattr(self, "path", None)
+    if getattr(self, "path", None):
+      if isinstance(self.path, str): self.path = Path(self.path)
+      return self.path
+    return None
 
   def is_required(self) -> bool:
     """Return ``True`` iff there exists no default value and it is mandatory that this reference be resolved."""
@@ -545,6 +548,8 @@ def _get_child_serializable(node, name):
     return _get_child(node.serialize_params, name)
   else:
     if not hasattr(node, name):
+      if name=="m":
+        print("break")
       raise PathError(f"{node} has no child named {name}")
     return getattr(node, name)
 

--- a/xnmt/persistence.py
+++ b/xnmt/persistence.py
@@ -1331,10 +1331,10 @@ def _resolve_serialize_refs(root):
       if not hasattr(node, "serialize_params"):
         raise ValueError(f"Cannot serialize node that has no serialize_params attribute: {node}\n"
                          "Did you forget to wrap the __init__() in @serializable_init ?")
-      xnmt.resolved_serialize_params[id(node)] = dict(node.serialize_params)
+      xnmt.resolved_serialize_params[id(node)] = node.serialize_params
     elif isinstance(node, collections.abc.MutableMapping):
       xnmt.resolved_serialize_params[id(node)] = dict(node)
-    elif isinstance(node, collections.abc.Sequence):
+    elif isinstance(node, collections.abc.MutableSequence):
       xnmt.resolved_serialize_params[id(node)] = list(node)
   if not ParamManager.param_col.all_subcol_owners <= all_serializable:
     raise RuntimeError(f"Not all registered DyNet parameter collections written out. "
@@ -1344,7 +1344,7 @@ def _resolve_serialize_refs(root):
   refs_inserted_at = set()
   refs_inserted_to = set()
   for path_to, node in _traverse_serializable(root):
-    if not refs_inserted_at & path_to.ancestors() and not refs_inserted_at & path_to.ancestors():
+    if not refs_inserted_at & path_to.ancestors():
       if isinstance(node, Serializable):
         for path_from, matching_node in _traverse_serializable(root):
           if not path_from in refs_inserted_to:

--- a/xnmt/persistence.py
+++ b/xnmt/persistence.py
@@ -547,9 +547,6 @@ def _get_child_serializable(node, name):
     if not hasattr(node, name):
       raise PathError(f"{node} has no child named {name}")
     return getattr(node, name)
-  # if not hasattr(node, name):
-  #   raise PathError(f"{node} has no child named {name}")
-  # return getattr(node, name)
 
 
 @singledispatch

--- a/xnmt/persistence.py
+++ b/xnmt/persistence.py
@@ -1332,7 +1332,7 @@ def _resolve_serialize_refs(root):
       if not hasattr(node, "serialize_params"):
         raise ValueError(f"Cannot serialize node that has no serialize_params attribute: {node}\n"
                          "Did you forget to wrap the __init__() in @serializable_init ?")
-      xnmt.resolved_serialize_params[id(node)] = node.serialize_params
+      xnmt.resolved_serialize_params[id(node)] = dict(node.serialize_params)
     elif isinstance(node, collections.abc.MutableMapping):
       xnmt.resolved_serialize_params[id(node)] = dict(node)
     elif isinstance(node, collections.abc.Sequence):

--- a/xnmt/persistence.py
+++ b/xnmt/persistence.py
@@ -1244,16 +1244,13 @@ class _YamlDeserializer(object):
       for shared_param_path in shared_param_set:
         try:
           new_shared_val = _get_descendant(root, shared_param_path)
-          # print('found {} = {}'.format(shared_param_path, new_shared_val))
         except PathError:
-          # print('found not {}'.format(shared_param_path))
           continue
         for _, child_of_shared_param in _traverse_tree(new_shared_val, include_root=False):
           if isinstance(child_of_shared_param, Serializable):
             raise ValueError(f"{path} shared params {shared_param_set} contains Serializable sub-object {child_of_shared_param} which is not permitted")
         if not isinstance(new_shared_val, Ref):
           shared_val_choices.add(new_shared_val)
-      # print('shared set {} == {}'.format(shared_param_set, shared_val_choices))
       if len(shared_val_choices)>1:
         logger.warning(f"inconsistent shared params at {path} for {shared_param_set}: {shared_val_choices}; Ignoring these shared parameters.")
       elif len(shared_val_choices)==1:

--- a/xnmt/persistence.py
+++ b/xnmt/persistence.py
@@ -547,6 +547,9 @@ def _get_child_serializable(node, name):
     if not hasattr(node, name):
       raise PathError(f"{node} has no child named {name}")
     return getattr(node, name)
+  # if not hasattr(node, name):
+  #   raise PathError(f"{node} has no child named {name}")
+  # return getattr(node, name)
 
 
 @singledispatch

--- a/xnmt/persistence.py
+++ b/xnmt/persistence.py
@@ -548,8 +548,6 @@ def _get_child_serializable(node, name):
     return _get_child(node.serialize_params, name)
   else:
     if not hasattr(node, name):
-      if name=="m":
-        print("break")
       raise PathError(f"{node} has no child named {name}")
     return getattr(node, name)
 

--- a/xnmt/reports.py
+++ b/xnmt/reports.py
@@ -29,7 +29,7 @@ from xnmt import sent, utils
 from xnmt.events import handle_xnmt_event, register_xnmt_handler
 from xnmt.persistence import Serializable, serializable_init, Ref
 from xnmt.settings import settings
-import xnmt.thirdparty.charcut.charcut as charcut
+from xnmt.thirdparty.charcut import charcut
 
 class ReportInfo(object):
   """

--- a/xnmt/thirdparty/charcut/charcut.py
+++ b/xnmt/thirdparty/charcut/charcut.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python2
-
 # CharCut: lightweight character-based MT output highlighting and scoring.
 # Copyright (C) 2017 Lardilleux
 #
@@ -25,7 +23,6 @@ so that they be reused in other projects.
 
 import argparse
 import difflib
-import gzip
 import math
 import re
 


### PR DESCRIPTION
In #508 I had attempted to fix an issue that required every ```__init__``` argument of a ```Serializable``` to be stored via ```self.arg_name = arg_name```. This is done anyways pretty much everywhere in XNMT, but would be nice to get rid of. The fix had introduced some new issues though which are probably worse and can lead to model saving or loading failing. I haven't been able to come up with a fix yet, so this PR reverts the previous fix and adds several unit tests and minor refactoring that will help with debugging and developing a fix. Also included is a test config with a cascading example (which was the one that led to some problems and made me aware of this).