### PR TITLE
Serializable instance attributes

### DIFF
--- a/test/test_persistence.py
+++ b/test/test_persistence.py
@@ -289,7 +289,6 @@ class TestSaving(unittest.TestCase):
     initalized = persistence.initialize_if_needed(preloaded)
     persistence.save_to_file(self.model_file, initalized)
 
-  @unittest.expectedFailure # TODO: need to fix case of serializable not storing its arguments as object members
   def test_mid(self):
     test_obj = yaml.load("""
                          a: !DummyArgClass
@@ -304,7 +303,6 @@ class TestSaving(unittest.TestCase):
     initalized = persistence.initialize_if_needed(preloaded)
     persistence.save_to_file(self.model_file, initalized)
 
-  @unittest.expectedFailure # TODO: need to fix case of serializable not storing its arguments as object members
   def test_deep(self):
     test_obj = yaml.load("""
                          a: !DummyArgClass
@@ -321,7 +319,6 @@ class TestSaving(unittest.TestCase):
     initalized = persistence.initialize_if_needed(preloaded)
     persistence.save_to_file(self.model_file, initalized)
 
-  @unittest.expectedFailure # TODO: need to fix case of serializable not storing its arguments as object members
   def test_double_ref(self):
     test_obj = yaml.load("""
                          a: !DummyArgClass

--- a/xnmt/persistence.py
+++ b/xnmt/persistence.py
@@ -91,6 +91,11 @@ def serializable_init(f):
     if "yaml_path" in serialize_params: del serialize_params["yaml_path"]
     obj.serialize_params = serialize_params
     obj.init_completed = True
+    # TODO: the below is needed for proper reference creation when saving the model, but should be replaced with
+    # something safer
+    for key, arg in serialize_params.items():
+      if not hasattr(obj, key):
+        setattr(obj, key, arg)
 
   wrapper.uses_serializable_init = True
   return wrapper


### PR DESCRIPTION
The current design requires Serializable objects to manually save their init arguments as instance attributes. This PR is a first improvement on this and makes this happen automatically, fixing a few unit tests. It should still be made a bit safer though in a future PR.