### PR TITLE
Hyperparams as numbers.Real

### DIFF
--- a/xnmt/batchers.py
+++ b/xnmt/batchers.py
@@ -4,6 +4,7 @@ import math
 import random
 from abc import ABC, abstractmethod
 from functools import lru_cache
+import numbers
 
 import numpy as np
 import dynet as dy
@@ -538,7 +539,7 @@ class WordSortBatcher(SortBatcher):
     pad_src_to_multiple: pad source sentences so its length is multiple of this integer.
   """
 
-  def __init__(self, words_per_batch: Optional[int], avg_batch_size: Optional[Union[int,float]], sort_key: Callable,
+  def __init__(self, words_per_batch: Optional[int], avg_batch_size: Optional[numbers.Real], sort_key: Callable,
                break_ties_randomly: bool = True, pad_src_to_multiple: int = 1) -> None:
     # Sanity checks
     if words_per_batch and avg_batch_size:
@@ -566,7 +567,7 @@ class WordSrcBatcher(WordSortBatcher, Serializable):
   yaml_tag = "!WordSrcBatcher"
 
   @serializable_init
-  def __init__(self, words_per_batch:Optional[int]=None, avg_batch_size:Optional[Union[int,float]]=None,
+  def __init__(self, words_per_batch:Optional[int]=None, avg_batch_size:Optional[numbers.Real]=None,
                break_ties_randomly:bool=True, pad_src_to_multiple:int=1) -> None:
     super().__init__(words_per_batch, avg_batch_size, sort_key=lambda x: x[0].sent_len(),
                      break_ties_randomly=break_ties_randomly,
@@ -592,7 +593,7 @@ class WordTrgBatcher(WordSortBatcher, Serializable):
   yaml_tag = "!WordTrgBatcher"
 
   @serializable_init
-  def __init__(self, words_per_batch:Optional[int]=None, avg_batch_size:Optional[Union[int,float]]=None,
+  def __init__(self, words_per_batch:Optional[int]=None, avg_batch_size:Optional[numbers.Real]=None,
                break_ties_randomly:bool=True, pad_src_to_multiple:int=1) -> None:
     super().__init__(words_per_batch, avg_batch_size, sort_key=lambda x: x[1].sent_len(),
                      break_ties_randomly=break_ties_randomly,
@@ -618,7 +619,7 @@ class WordSrcTrgBatcher(WordSortBatcher, Serializable):
   yaml_tag = "!WordSrcTrgBatcher"
 
   @serializable_init
-  def __init__(self, words_per_batch: Optional[int] = None, avg_batch_size: Optional[Union[int, float]] = None,
+  def __init__(self, words_per_batch: Optional[int] = None, avg_batch_size: Optional[numbers.Real] = None,
                break_ties_randomly: bool = True, pad_src_to_multiple: bool = 1) -> None:
     super().__init__(words_per_batch, avg_batch_size, sort_key=lambda x: x[0].sent_len() + 1.0e-6 * x[1].sent_len(),
                      break_ties_randomly=break_ties_randomly,
@@ -644,7 +645,7 @@ class WordTrgSrcBatcher(WordSortBatcher, Serializable):
   yaml_tag = "!WordTrgSrcBatcher"
 
   @serializable_init
-  def __init__(self, words_per_batch: Optional[int] = None, avg_batch_size: Optional[Union[int, float]] = None,
+  def __init__(self, words_per_batch: Optional[int] = None, avg_batch_size: Optional[numbers.Real] = None,
                break_ties_randomly: bool = True, pad_src_to_multiple: int = 1) -> None:
     super().__init__(words_per_batch, avg_batch_size, sort_key=lambda x: x[1].sent_len() + 1.0e-6 * x[0].sent_len(),
                      break_ties_randomly=break_ties_randomly,

--- a/xnmt/eval/metrics.py
+++ b/xnmt/eval/metrics.py
@@ -20,6 +20,7 @@ from collections import defaultdict, Counter
 import math
 import subprocess
 from typing import List, Sequence, Dict, Tuple, Union, Any, Optional
+import numbers
 
 import yaml
 import numpy as np
@@ -125,8 +126,8 @@ class LossScore(EvalScore, Serializable):
   yaml_tag = "!LossScore"
 
   @serializable_init
-  def __init__(self, loss: float, loss_stats: Dict[str, float] = None, num_ref_words: Optional[int] = None,
-               desc: Any = None) -> None:
+  def __init__(self, loss: numbers.Real, loss_stats: Dict[str, numbers.Real] = None,
+               num_ref_words: Optional[int] = None, desc: Any = None) -> None:
     super().__init__(desc=desc)
     self.loss = loss
     self.loss_stats = loss_stats
@@ -159,8 +160,14 @@ class BLEUScore(EvalScore, Serializable):
   yaml_tag = "!BLEUScore"
 
   @serializable_init
-  def __init__(self, bleu: float, frac_score_list: Sequence[float] = None, brevity_penalty_score: float = None,
-               hyp_len: int = None, ref_len: int = None, ngram: int = 4, desc: Any = None) -> None:
+  def __init__(self,
+               bleu: numbers.Real,
+               frac_score_list: Sequence[numbers.Real] = None,
+               brevity_penalty_score: numbers.Real = None,
+               hyp_len: int = None,
+               ref_len: int = None,
+               ngram: int = 4,
+               desc: Any = None) -> None:
     self.bleu = bleu
     self.frac_score_list = frac_score_list
     self.brevity_penalty_score = brevity_penalty_score
@@ -291,7 +298,7 @@ class RecallScore(SentenceLevelEvalScore, Serializable):
   yaml_tag = "!RecallScore"
 
   @serializable_init
-  def __init__(self, recall: float, hyp_len: int, ref_len: int, nbest: int = 5, desc: Any = None) -> None:
+  def __init__(self, recall: numbers.Real, hyp_len: int, ref_len: int, nbest: int = 5, desc: Any = None) -> None:
     self.recall  = recall
     self.hyp_len = hyp_len
     self.ref_len = ref_len
@@ -327,7 +334,7 @@ class ExternalScore(EvalScore, Serializable):
   yaml_tag = "!ExternalScore"
 
   @serializable_init
-  def __init__(self, value: float, higher_is_better: bool = True, desc: Any = None) -> None:
+  def __init__(self, value: numbers.Real, higher_is_better: bool = True, desc: Any = None) -> None:
     self.value = value
     self.higher_is_better = higher_is_better
     self.desc = desc
@@ -479,7 +486,7 @@ class FastBLEUEvaluator(SentenceLevelEvaluator, Serializable):
   yaml_tag = "!FastBLEUEvaluator"
 
   @serializable_init
-  def __init__(self, ngram:int = 4, smooth:float = 1):
+  def __init__(self, ngram:int = 4, smooth:numbers.Real = 1):
     self.ngram = ngram
     self.weights = (1 / ngram) * np.ones(ngram, dtype=np.float32)
     self.smooth = smooth

--- a/xnmt/experiments.py
+++ b/xnmt/experiments.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List, Optional
+import numbers
 
 from xnmt.param_initializers import ParamInitializer, GlorotInitializer, ZeroInitializer
 from xnmt.settings import settings
@@ -38,8 +39,8 @@ class ExpGlobal(Serializable):
   def __init__(self,
                model_file: str = settings.DEFAULT_MOD_PATH,
                log_file: str = settings.DEFAULT_LOG_PATH,
-               dropout: float = 0.3,
-               weight_noise: float = 0.0,
+               dropout: numbers.Real = 0.3,
+               weight_noise: numbers.Real = 0.0,
                default_layer_dim: int = 512,
                param_init: ParamInitializer = bare(GlorotInitializer),
                bias_init: ParamInitializer = bare(ZeroInitializer),

--- a/xnmt/hyper_params.py
+++ b/xnmt/hyper_params.py
@@ -1,3 +1,4 @@
+import typing
 import numbers
 
 from xnmt.events import register_xnmt_handler, handle_xnmt_event
@@ -10,23 +11,23 @@ class Scalar(Serializable):
   
   Args:
     initial: The value being hold by the scalar.
-    update: Is the epoch number. 
+    times_updated: Is the epoch number.
   """
 
   yaml_tag = "!Scalar"
   
   @serializable_init
   @register_xnmt_handler
-  def __init__(self, initial=0.0, update=0):
+  def __init__(self, initial=0.0, times_updated=0):
     self.value = initial
-    self.times_updated = update
+    self.times_updated = times_updated
 
   @handle_xnmt_event
   def on_new_epoch(self, *args, **kwargs):
     self.value = self.update_value()
     self.times_updated += 1
     self.save_processed_arg("initial", self.value)
-    self.save_processed_arg("update", self.times_updated)
+    self.save_processed_arg("times_updated", self.times_updated)
  
   def update_value(self):
     return self.value
@@ -60,15 +61,14 @@ class DefinedSequence(Scalar):
   
   Args:
     sequence: A list of numbers
-    initial: The current value or the value.
-    update: The epoch number
+    times_updated: The epoch number
   """
   
   yaml_tag = "!DefinedSequence"
 
   @serializable_init
-  def __init__(self, sequence=None, initial=0.0, update=0):
-    super().__init__(initial, update)
+  def __init__(self, sequence: typing.Sequence[numbers.Real], times_updated: int = 0):
+    super().__init__(initial=sequence[0], times_updated=times_updated)
     self.sequence = sequence
 
   def update_value(self):

--- a/xnmt/hyper_params.py
+++ b/xnmt/hyper_params.py
@@ -19,18 +19,21 @@ class Scalar(Serializable):
   @serializable_init
   @register_xnmt_handler
   def __init__(self, initial=0.0, times_updated=0):
-    self.value = initial
+    self.initial = initial
     self.times_updated = times_updated
+    self.value = self.get_curr_value()
 
   @handle_xnmt_event
   def on_new_epoch(self, *args, **kwargs):
-    self.value = self.update_value()
+    self.value = self.get_curr_value()
     self.times_updated += 1
-    self.save_processed_arg("initial", self.value)
     self.save_processed_arg("times_updated", self.times_updated)
  
-  def update_value(self):
-    return self.value
+  def get_curr_value(self):
+    return self.initial
+
+  def __repr__(self):
+    return f"{self.__class__.__name__}[curr={self.get_curr_value()}]"
 
   # Operators
   def __lt__(a, b): return a.value < b
@@ -48,17 +51,19 @@ class Scalar(Serializable):
   def __truediv__(a, b): return a.value / b
   def __floordiv__(a, b): return a.value // b
 
-class DefinedSequence(Scalar):
+class DefinedSequence(Scalar, Serializable):
   """
   Class that represents a fixed defined sequence from config files.
   If update has been made more than the length of the sequence, the last element of the sequence will be returned instead
   
   x = DefinedSequence([0.1, 0.5, 1])
   
-  # Epoch 1: 0+x = 0.1
-  # Epoch 2: 0+x = 0.5
-  # Epoch 3: 0+x = 1
-  
+  # Epoch 1: 0.1
+  # Epoch 2: 0.5
+  # Epoch 3: 1
+  # Epoch 4: 1
+  # ...
+
   Args:
     sequence: A list of numbers
     times_updated: The epoch number
@@ -68,10 +73,11 @@ class DefinedSequence(Scalar):
 
   @serializable_init
   def __init__(self, sequence: typing.Sequence[numbers.Real], times_updated: int = 0):
-    super().__init__(initial=sequence[0], times_updated=times_updated)
     self.sequence = sequence
+    if len(sequence)==0: raise ValueError("DefinedSequence initialized with empty sequence")
+    super().__init__(times_updated=times_updated)
 
-  def update_value(self):
+  def get_curr_value(self):
     return self.sequence[min(len(self.sequence) - 1, self.times_updated)]
 
 numbers.Real.register(Scalar)

--- a/xnmt/hyper_params.py
+++ b/xnmt/hyper_params.py
@@ -1,3 +1,5 @@
+import numbers
+
 from xnmt.events import register_xnmt_handler, handle_xnmt_event
 from xnmt.persistence import serializable_init, Serializable
 
@@ -17,14 +19,14 @@ class Scalar(Serializable):
   @register_xnmt_handler
   def __init__(self, initial=0.0, update=0):
     self.value = initial
-    self.update = update
+    self.times_updated = update
 
   @handle_xnmt_event
   def on_new_epoch(self, *args, **kwargs):
     self.value = self.update_value()
-    self.update += 1
+    self.times_updated += 1
     self.save_processed_arg("initial", self.value)
-    self.save_processed_arg("update", self.update)
+    self.save_processed_arg("update", self.times_updated)
  
   def update_value(self):
     return self.value
@@ -70,5 +72,6 @@ class DefinedSequence(Scalar):
     self.sequence = sequence
 
   def update_value(self):
-    return self.sequence[min(len(self.sequence)-1, self.update)]
+    return self.sequence[min(len(self.sequence) - 1, self.times_updated)]
 
+numbers.Real.register(Scalar)

--- a/xnmt/inferences.py
+++ b/xnmt/inferences.py
@@ -1,5 +1,6 @@
 import collections.abc
 from typing import List, Optional, Tuple, Sequence, Union
+import numbers
 
 from xnmt.settings import settings
 
@@ -93,7 +94,7 @@ class Inference(object):
   def _generate_output(self, generator: 'models.GeneratorModel', src_corpus: Sequence[sent.Sentence],
                        trg_file: str, batcher: Optional[batchers.Batcher] = None, max_src_len: Optional[int] = None,
                        forced_ref_corpus: Optional[Sequence[sent.Sentence]] = None,
-                       assert_scores: Optional[Sequence[float]] = None) -> None:
+                       assert_scores: Optional[Sequence[numbers.Real]] = None) -> None:
     """
     Generate outputs and write them to file.
 
@@ -155,7 +156,7 @@ class Inference(object):
     for reporter in self.reporter:
       reporter.conclude_report()
 
-  def _compute_losses(self, generator, ref_corpus, src_corpus, max_num_sents) -> List[float]:
+  def _compute_losses(self, generator, ref_corpus, src_corpus, max_num_sents) -> List[numbers.Real]:
     batched_src, batched_ref = self.batcher.pack(src_corpus, ref_corpus)
     ref_scores = []
     for sent_count, (src, ref) in enumerate(zip(batched_src, batched_ref)):
@@ -171,7 +172,7 @@ class Inference(object):
 
 
   @staticmethod
-  def _write_rescored_output(ref_scores: Sequence[float], ref_file: str, trg_file: str) -> None:
+  def _write_rescored_output(ref_scores: Sequence[numbers.Real], ref_file: str, trg_file: str) -> None:
     """
     Write scored sequences and scores to file when mode=='score'.
 

--- a/xnmt/length_norm.py
+++ b/xnmt/length_norm.py
@@ -1,4 +1,4 @@
-from numbers import Real
+import numbers
 from typing import Sequence, Optional
 
 import numpy as np
@@ -57,7 +57,7 @@ class AdditiveNormalization(LengthNormalization, Serializable):
   yaml_tag = '!AdditiveNormalization'
 
   @serializable_init
-  def __init__(self, penalty: Real = -0.1, apply_during_search: bool = False):
+  def __init__(self, penalty: numbers.Real = -0.1, apply_during_search: bool = False):
     self.penalty = penalty
     self.apply_during_search = apply_during_search
 
@@ -78,7 +78,7 @@ class PolynomialNormalization(LengthNormalization, Serializable):
   yaml_tag = '!PolynomialNormalization'
 
   @serializable_init
-  def __init__(self, m: Real = 1, apply_during_search: bool = False):
+  def __init__(self, m: numbers.Real = 1, apply_during_search: bool = False):
     self.m = m
     self.apply_during_search = apply_during_search
     self.pows = []
@@ -175,7 +175,7 @@ class EosBooster(Serializable):
   """
   yaml_tag = "!EosBooster"
   @serializable_init
-  def __init__(self, boost_val: float):
+  def __init__(self, boost_val: numbers.Real):
     self.boost_val = boost_val
   def __call__(self, scores:np.ndarray) -> None:
     scores[Vocab.ES] += self.boost_val

--- a/xnmt/modelparts/scorers.py
+++ b/xnmt/modelparts/scorers.py
@@ -1,5 +1,7 @@
-import dynet as dy
 from typing import List, Union, Optional
+import numbers
+
+import dynet as dy
 
 from xnmt import batchers, input_readers, param_collections, param_initializers, vocabs
 from xnmt.modelparts import transforms
@@ -108,7 +110,7 @@ class Softmax(Scorer, Serializable):
                vocab_size: Optional[int] = None,
                vocab: Optional[vocabs.Vocab] = None,
                trg_reader: Optional[input_readers.InputReader] = Ref("model.trg_reader", default=None),
-               label_smoothing: float = 0.0,
+               label_smoothing: numbers.Real = 0.0,
                param_init: param_initializers.ParamInitializer = Ref("exp_global.param_init", default=bare(param_initializers.GlorotInitializer)),
                bias_init: param_initializers.ParamInitializer = Ref("exp_global.bias_init", default=bare(param_initializers.ZeroInitializer)),
                output_projector: transforms.Linear = None) -> None:

--- a/xnmt/param_initializers.py
+++ b/xnmt/param_initializers.py
@@ -1,4 +1,6 @@
 import math
+from typing import Tuple
+import numbers
 
 import numpy as np
 import dynet as dy
@@ -10,12 +12,12 @@ class ParamInitializer(object):
   A parameter initializer that delegates to the DyNet initializers and possibly
   performs some extra configuration.
   """
-  def initializer(self, dim, is_lookup=False, num_shared=1):
+  def initializer(self, dim: Tuple[int], is_lookup: bool = False, num_shared: int = 1):
     """
     Args:
-      dim (tuple of int): dimension of parameter tensor
-      is_lookup (bool): True if parameters are a lookup matrix
-      num_shared (int): Indicates if one parameter object holds multiple matrices
+      dim: dimension of parameter tensor
+      is_lookup: True if parameters are a lookup matrix
+      num_shared: Indicates if one parameter object holds multiple matrices
     Returns:
       a dynet initializer object
     """
@@ -30,13 +32,13 @@ class NormalInitializer(ParamInitializer, Serializable):
   Initialize the parameters with a gaussian distribution.
 
   Args:
-    mean (float): Mean of the distribution
-    var (float): Variance of the distribution
+    mean: Mean of the distribution
+    var: Variance of the distribution
   """
   yaml_tag = "!NormalInitializer"
 
   @serializable_init
-  def __init__(self, mean=0, var=1):
+  def __init__(self, mean: numbers.Real = 0, var: numbers.Real = 1):
     self.mean = mean
     self.var = var
   def initializer(self, dim, is_lookup=False, num_shared=1):
@@ -48,12 +50,12 @@ class UniformInitializer(ParamInitializer, Serializable):
 
   Initialize the parameters with a uniform distribution.
   Args:
-    scale (float): Parameters are sampled from :math:`\\mathcal U([-\\texttt{scale},\\texttt{scale}])`
+    scale: Parameters are sampled from :math:`\\mathcal U([-\\texttt{scale},\\texttt{scale}])`
   """
   yaml_tag = "!UniformInitializer"
 
   @serializable_init
-  def __init__(self, scale):
+  def __init__(self, scale: numbers.Real):
     self.scale = scale
   def initializer(self, dim, is_lookup=False, num_shared=1):
     return dy.UniformInitializer(scale=self.scale)
@@ -65,12 +67,12 @@ class ConstInitializer(ParamInitializer, Serializable):
   Initialize the parameters with a constant value.
 
   Args:
-    c (float): Value to initialize the parameters
+    c: Value to initialize the parameters
   """
   yaml_tag = "!ConstInitializer"
 
   @serializable_init
-  def __init__(self, c):
+  def __init__(self, c: numbers.Real):
     self.c = c
   def initializer(self, dim, is_lookup=False, num_shared=1):
     return dy.ConstInitializer(c=self.c)
@@ -95,12 +97,12 @@ class GlorotInitializer(ParamInitializer, Serializable):
     *Note:* This is also known as **Xavier initialization**
 
   Args:
-    gain (float): Gain (Depends on the activation function)
+    gain: Gain (Depends on the activation function)
   """
   yaml_tag = "!GlorotInitializer"
 
   @serializable_init
-  def __init__(self, gain=1.0):
+  def __init__(self, gain: numbers.Real = 1.0):
     self.gain = gain
   def initializer(self, dim:tuple, is_lookup:bool=False, num_shared:int=1):
     """
@@ -129,12 +131,12 @@ class FromFileInitializer(ParamInitializer, Serializable):
   Initialize parameter from file.
 
   Args:
-    fname (str): File name
+    fname: File name
   """
   yaml_tag = "!FromFileInitializer"
 
   @serializable_init
-  def __init__(self, fname):
+  def __init__(self, fname: str):
     self.fname = fname
   def initializer(self, dim, is_lookup=False, num_shared=1):
     return dy.FromFileInitializer(fname=self.fname)
@@ -148,12 +150,12 @@ class NumpyInitializer(ParamInitializer, Serializable):
   Alternatively, use ``ParameterCollection.parameters_from_numpy()``
 
   Args:
-    array (np.ndarray): Numpy array
+    array: Numpy array
   """
   yaml_tag = "!NumpyInitializer"
 
   @serializable_init
-  def __init__(self, array):
+  def __init__(self, array: np.ndarray):
     self.array = array
   def initializer(self, dim, is_lookup=False, num_shared=1):
     return dy.NumpyInitializer(array=self.array)
@@ -180,12 +182,12 @@ class LeCunUniformInitializer(ParamInitializer, Serializable):
   http://yann.lecun.com/exdb/publis/pdf/lecun-98b.pdf
 
   Args:
-    scale (float): scale
+    scale: scale
   """
   yaml_tag = "!LeCunUniformInitializer"
 
   @serializable_init
-  def __init__(self, scale=1.0):
+  def __init__(self, scale: numbers.Real = 1.0):
     self.scale = scale
 
   def initializer(self, dim, is_lookup=False, num_shared=1):

--- a/xnmt/persistence.py
+++ b/xnmt/persistence.py
@@ -1327,7 +1327,7 @@ def _resolve_serialize_refs(root):
   # gather all non-basic types (Serializable, list, dict) in the global dictionary xnmt.resolved_serialize_params
   for _, node in _traverse_serializable(root):
     if isinstance(node, Serializable):
-      all_serializable.add(node)
+      all_serializable.add(id(node))
       if not hasattr(node, "serialize_params"):
         raise ValueError(f"Cannot serialize node that has no serialize_params attribute: {node}\n"
                          "Did you forget to wrap the __init__() in @serializable_init ?")
@@ -1337,7 +1337,7 @@ def _resolve_serialize_refs(root):
     elif isinstance(node, collections.abc.MutableSequence):
       xnmt.resolved_serialize_params[id(node)] = list(node)
 
-  if not ParamManager.param_col.all_subcol_owners <= all_serializable:
+  if not set(id(o) for o in ParamManager.param_col.all_subcol_owners) <= all_serializable:
     raise RuntimeError(f"Not all registered DyNet parameter collections written out. "
                        f"Missing: {ParamManager.param_col.all_subcol_owners - all_serializable}.\n"
                        f"This indicates that potentially not all components adhere to the protocol of using "

--- a/xnmt/reports.py
+++ b/xnmt/reports.py
@@ -17,6 +17,7 @@ import os
 import math
 from typing import Any, Dict, Optional, Sequence, Union
 from collections import defaultdict
+import numbers
 
 from bs4 import BeautifulSoup as bs
 
@@ -194,7 +195,7 @@ class CompareMtReporter(Reporter, Serializable):
   @serializable_init
   @register_xnmt_handler
   def __init__(self, out2_file: Optional[str] = None, train_file: Optional[str] = None,
-               train_counts: Optional[str] = None, alpha: float = 1.0, ngram: int = 4, ngram_size: int = 50,
+               train_counts: Optional[str] = None, alpha: numbers.Real = 1.0, ngram: int = 4, ngram_size: int = 50,
                sent_size: int = 10, report_path: str = settings.DEFAULT_REPORT_PATH) -> None:
     self.out2_file = out2_file
     self.train_file = train_file

--- a/xnmt/sent.py
+++ b/xnmt/sent.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Sequence, Union
 import functools
-import copy
+import numbers
 
 import numpy as np
 
@@ -16,7 +16,7 @@ class Sentence(object):
     score: a score given to this sentence by a model
   """
 
-  def __init__(self, idx: Optional[int] = None, score: Optional[float] = None) -> None:
+  def __init__(self, idx: Optional[int] = None, score: Optional[numbers.Real] = None) -> None:
     self.idx = idx
     self.score = score
 
@@ -66,7 +66,7 @@ class ReadableSentence(Sentence):
     score: a score given to this sentence by a model
     output_procs: output processors to be applied when calling sent_str()
   """
-  def __init__(self, idx: int, score: float = None,
+  def __init__(self, idx: int, score: Optional[numbers.Real] = None,
                output_procs: Union[OutputProcessor, Sequence[OutputProcessor]] = []) -> None:
     super().__init__(idx=idx, score=score)
     self.output_procs = output_procs
@@ -117,7 +117,7 @@ class ScalarSentence(ReadableSentence):
     score: a score given to this sentence by a model
   """
   def __init__(self, value: int, idx: Optional[int] = None, vocab: Optional[Vocab] = None,
-               score: Optional[float] = None) -> None:
+               score: Optional[numbers.Real] = None) -> None:
     super().__init__(idx=idx, score=score)
     self.value = value
     self.vocab = vocab
@@ -174,7 +174,7 @@ class SimpleSentence(ReadableSentence):
     pad_token: special token used for padding
   """
   def __init__(self, words: Sequence[int], idx: Optional[int] = None, vocab: Optional[Vocab] = None,
-               score: Optional[float] = None, output_procs: Union[OutputProcessor, Sequence[OutputProcessor]] = [],
+               score: Optional[numbers.Real] = None, output_procs: Union[OutputProcessor, Sequence[OutputProcessor]] = [],
                pad_token: int = Vocab.ES) -> None:
     super().__init__(idx=idx, score=score, output_procs=output_procs)
     self.pad_token = pad_token
@@ -251,7 +251,7 @@ class ArraySentence(Sentence):
   """
 
   def __init__(self, nparr: np.ndarray, idx: Optional[int] = None, padded_len: int = 0,
-               score: Optional[float] = None) -> None:
+               score: Optional[numbers.Real] = None) -> None:
     super().__init__(idx=idx, score=score)
     self.nparr = nparr
     self.padded_len = padded_len

--- a/xnmt/specialized_encoders/self_attentional_am.py
+++ b/xnmt/specialized_encoders/self_attentional_am.py
@@ -11,7 +11,7 @@ The main class to be aware of is :class:`SAAMSeqTransducer`.
 
 import typing
 import logging
-
+import numbers
 
 yaml_logger = logging.getLogger('yaml')
 from collections.abc import Sequence
@@ -123,7 +123,7 @@ class SAAMMultiHeadedSelfAttention(Serializable):
   @serializable_init
   def __init__(self, head_count: int, model_dim: int, downsample_factor: int = 1, input_dim: int = None,
                ignore_masks: bool = False, plot_attention: typing.Optional[str] = None,
-               diag_gauss_mask: typing.Union[bool, float, int] = False,
+               diag_gauss_mask: typing.Union[bool, numbers.Real] = False,
                square_mask_std: bool = True, cross_pos_encoding_type: typing.Optional[str] = None,
                kq_pos_encoding_type: typing.Optional[str] = None, kq_pos_encoding_size: int = 40, max_len: int = 1500,
                param_init: xnmt.param_initializers.ParamInitializer = xnmt.param_initializers.GlorotInitializer(),
@@ -218,7 +218,7 @@ class SAAMMultiHeadedSelfAttention(Serializable):
     out = dy.transpose(out)
     return dy.reshape(out, (seq_len, self.dim_per_head), batch_size=batch_size * self.head_count)
 
-  def __call__(self, x: dy.Expression, att_mask: np.ndarray, batch_mask: np.ndarray, p: float):
+  def __call__(self, x: dy.Expression, att_mask: np.ndarray, batch_mask: np.ndarray, p: numbers.Real):
     """
     x: expression of dimensions (input_dim, time) x batch
     att_mask: numpy array of dimensions (time, time); pre-transposed
@@ -503,10 +503,10 @@ class SAAMSeqTransducer(transducers.SeqTransducer, Serializable):
   @serializable_init
   @events.register_xnmt_handler
   def __init__(self, input_dim:int=512, layers:int=1, hidden_dim:int=512, head_count:int=8, ff_hidden_dim:int=2048,
-               dropout:float=Ref("exp_global.dropout", default=0.0), downsample_factor:int=1, diagonal_mask_width:int=None,
+               dropout:numbers.Real=Ref("exp_global.dropout", default=0.0), downsample_factor:int=1, diagonal_mask_width:int=None,
                ignore_masks:bool=False, plot_attention:typing.Optional[str]=None, nonlinearity:str="rectify", pos_encoding_type:typing.Optional[str]=None,
-               pos_encoding_combine:str="concat", pos_encoding_size:int=40, max_len:int=1500, diag_gauss_mask:typing.Union[bool,float,int]=False,
-               square_mask_std:float=True, cross_pos_encoding_type:typing.Optional[str]=None, ff_lstm:bool=False, kq_pos_encoding_type:typing.Optional[str]=None,
+               pos_encoding_combine:str="concat", pos_encoding_size:int=40, max_len:int=1500, diag_gauss_mask:typing.Union[bool,numbers.Real]=False,
+               square_mask_std:numbers.Real=True, cross_pos_encoding_type:typing.Optional[str]=None, ff_lstm:bool=False, kq_pos_encoding_type:typing.Optional[str]=None,
                kq_pos_encoding_size:int=40,
                param_init:xnmt.param_initializers.ParamInitializer=Ref("exp_global.param_init", default=bare(xnmt.param_initializers.GlorotInitializer)),
                bias_init:xnmt.param_initializers.ParamInitializer=Ref("exp_global.bias_init", default=bare(xnmt.param_initializers.ZeroInitializer)),

--- a/xnmt/train/regimens.py
+++ b/xnmt/train/regimens.py
@@ -1,6 +1,7 @@
 import contextlib
 from typing import Sequence, Optional, Union
 from collections import OrderedDict
+import numbers
 
 from xnmt.settings import settings
 import numpy as np
@@ -94,7 +95,7 @@ class SimpleTrainingRegimen(train_tasks.SimpleTrainingTask, TrainingRegimen, Ser
                batcher: batchers.Batcher = bare(batchers.SrcBatcher, batch_size=32),
                loss_calculator: LossCalculator = bare(MLELoss),
                trainer: optimizers.XnmtOptimizer = bare(optimizers.SimpleSGDTrainer, e0=0.1),
-               run_for_epochs: Optional[int] = None, lr_decay: float = 1.0, lr_decay_times: int = 3, patience: int = 1,
+               run_for_epochs: Optional[int] = None, lr_decay: numbers.Real= 1.0, lr_decay_times: int = 3, patience: int = 1,
                initial_patience: Optional[int] = None, dev_tasks: Sequence[eval_tasks.EvalTask] = None,
                dev_combinator: Optional[str] = None, restart_trainer: bool = False,
                reload_command: Optional[str] = None, name: str = "{EXP}", sample_train_sents: Optional[int] = None,
@@ -346,7 +347,7 @@ class AlternatingBatchMultiTaskTrainingRegimen(MultiTaskTrainingRegimen, Seriali
   @serializable_init
   def __init__(self,
                tasks: Sequence[train_tasks.TrainingTask],
-               task_weights: Optional[Sequence[float]] = None,
+               task_weights: Optional[Sequence[numbers.Real]] = None,
                trainer: optimizers.XnmtOptimizer = bare(optimizers.SimpleSGDTrainer, e0=0.1),
                dev_zero: bool = False,
                loss_comb_method: str = Ref("exp_global.loss_comb_method", default="sum"),

--- a/xnmt/train/tasks.py
+++ b/xnmt/train/tasks.py
@@ -1,8 +1,10 @@
 from subprocess import Popen
 from asteval import Interpreter
 import random
-import numpy as np
 from typing import Iterator, Optional, Sequence, Union
+import numbers
+
+import numpy as np
 
 from xnmt import batchers, event_trigger, input_readers, logger, losses, loss_trackers, loss_calculators, \
   param_collections
@@ -117,7 +119,7 @@ class SimpleTrainingTask(TrainingTask, Serializable):
                batcher: batchers.Batcher = bare(batchers.SrcBatcher, batch_size=32),
                loss_calculator: loss_calculators.LossCalculator = bare(loss_calculators.MLELoss),
                run_for_epochs: Optional[int] = None,
-               lr_decay: float = 1.0, lr_decay_times: int = 3,
+               lr_decay: numbers.Real = 1.0, lr_decay_times: int = 3,
                patience: int = 1, initial_patience: Optional[int] = None,
                dev_tasks: Sequence['eval_tasks.EvalTask'] = None, dev_combinator=None,
                restart_trainer: bool = False,

--- a/xnmt/transducers/pyramidal.py
+++ b/xnmt/transducers/pyramidal.py
@@ -1,5 +1,5 @@
 import dynet as dy
-from typing import List
+from typing import Any, List, Sequence, Union
 
 from xnmt.transducers.recurrent import UniLSTMSeqTransducer
 from xnmt.expression_seqs import ExpressionSequence, ReversedExpressionSequence
@@ -16,24 +16,26 @@ class PyramidalLSTMSeqTransducer(SeqTransducer, Serializable):
   Every layer (except the first) reduces sequence length by the specified factor.
 
   Args:
-    layers (int): number of layers
-    input_dim (int): input dimension
-    hidden_dim (int): hidden dimension
-    downsampling_method (str): how to perform downsampling (concat|skip)
-    reduce_factor (Union[int,List[int]): integer, or list of ints (different skip for each layer)
-    dropout (float): dropout probability; if None, use exp_global.dropout
+    layers: number of layers
+    input_dim: input dimension
+    hidden_dim: hidden dimension
+    downsampling_method: how to perform downsampling (concat|skip)
+    reduce_factor: integer, or list of ints (different skip for each layer)
+    dropout: dropout probability; if None, use exp_global.dropout
+    builder_layers: set automatically
   """
   yaml_tag = '!PyramidalLSTMSeqTransducer'
 
   @register_xnmt_handler
   @serializable_init
-  def __init__(self, layers=1,
-               input_dim=Ref("exp_global.default_layer_dim"),
-               hidden_dim=Ref("exp_global.default_layer_dim"),
-               downsampling_method="concat",
-               reduce_factor=2,
-               dropout=Ref("exp_global.dropout", default=0.0),
-               builder_layers=None):
+  def __init__(self,
+               layers: int = 1,
+               input_dim: int = Ref("exp_global.default_layer_dim"),
+               hidden_dim: int = Ref("exp_global.default_layer_dim"),
+               downsampling_method: str = "concat",
+               reduce_factor: Union[int, Sequence[int]] = 2,
+               dropout: float = Ref("exp_global.dropout", default=0.0),
+               builder_layers: Any = None):
     self.dropout = dropout
     assert layers > 0
     assert hidden_dim % 2 == 0


### PR DESCRIPTION
Using ```hyperparam.Scalar``` etc. in my config file led to a failing type check because ```Scalar``` is not a ```float```.

To solve this, I made ```Scalar``` an instance of Python's abstract base class ```numbers.Real```, and updated the type annotations to use numbers.Real instead of float. Also includes some general improvements toward more consistent type annotations.

I think as a general goal we should try to use the abstract base class type variants whenever possible (e.g. also for ```numbers.Integral```, and possibly for a new string-type ABC) because that will enable making hyperparams and ```!Ref``` to be compatible with these types.

Update: I also slightly updated ```DefinedSequence``` to use its first list item as initial value.