### PR TITLE
Sentence Filter after corpus reading

### DIFF
--- a/xnmt/input_readers.py
+++ b/xnmt/input_readers.py
@@ -408,7 +408,8 @@ class IDReader(BaseTextReader, Serializable):
 
 ###### A utility function to read a parallel corpus
 def read_parallel_corpus(src_reader: InputReader, trg_reader: InputReader, src_file: str, trg_file: str,
-                         batcher: batchers.Batcher=None, sample_sents=None, max_num_sents=None, max_src_len=None, max_trg_len=None):
+                         batcher: batchers.Batcher=None, sample_sents=None, max_num_sents=None, max_src_len=None, max_trg_len=None,
+                         filter=None):
   """
   A utility function to read a parallel corpus.
 
@@ -439,6 +440,8 @@ def read_parallel_corpus(src_reader: InputReader, trg_reader: InputReader, src_f
     logger.info(f"Starting to read {src_file} and {trg_file}")
     filter_ids = None
     src_len, trg_len = 0, 0
+
+
   src_train_iterator = src_reader.read_sents(src_file, filter_ids)
   trg_train_iterator = trg_reader.read_sents(trg_file, filter_ids)
   for src_sent, trg_sent in zip_longest(src_train_iterator, trg_train_iterator):
@@ -448,7 +451,22 @@ def read_parallel_corpus(src_reader: InputReader, trg_reader: InputReader, src_f
       break
     src_len_ok = max_src_len is None or src_sent.sent_len() <= max_src_len
     trg_len_ok = max_trg_len is None or trg_sent.sent_len() <= max_trg_len
-    if src_len_ok and trg_len_ok:
+    keep_sent = src_len_ok and trg_len_ok
+
+    if filter is not None and keep_sent:
+      if hasattr(trg_sent, "words"):
+        tmp_trg_sent = [e.replace("__", " ") for e in [trg_reader.vocab[i] for i in trg_sent.words][:-1]]
+      else:
+        tmp_trg_sent = trg_sent
+      if hasattr(src_sent, "words"):
+        tmp_src_sent = [e.replace("__", " ") for e in [src_reader.vocab[i] for i in src_sent.words][:-1]]
+      else:
+        tmp_src_sent = src_sent
+
+      keep_sent = filter.keep([tmp_src_sent, tmp_trg_sent])
+
+
+    if keep_sent:
       src_data.append(src_sent)
       trg_data.append(trg_sent)
 

--- a/xnmt/input_readers.py
+++ b/xnmt/input_readers.py
@@ -440,8 +440,6 @@ def read_parallel_corpus(src_reader: InputReader, trg_reader: InputReader, src_f
     logger.info(f"Starting to read {src_file} and {trg_file}")
     filter_ids = None
     src_len, trg_len = 0, 0
-
-
   src_train_iterator = src_reader.read_sents(src_file, filter_ids)
   trg_train_iterator = trg_reader.read_sents(trg_file, filter_ids)
   for src_sent, trg_sent in zip_longest(src_train_iterator, trg_train_iterator):
@@ -464,7 +462,6 @@ def read_parallel_corpus(src_reader: InputReader, trg_reader: InputReader, src_f
         tmp_src_sent = src_sent
 
       keep_sent = sent_filter.keep([tmp_src_sent, tmp_trg_sent])
-
 
     if keep_sent:
       src_data.append(src_sent)

--- a/xnmt/input_readers.py
+++ b/xnmt/input_readers.py
@@ -409,7 +409,7 @@ class IDReader(BaseTextReader, Serializable):
 ###### A utility function to read a parallel corpus
 def read_parallel_corpus(src_reader: InputReader, trg_reader: InputReader, src_file: str, trg_file: str,
                          batcher: batchers.Batcher=None, sample_sents=None, max_num_sents=None, max_src_len=None, max_trg_len=None,
-                         filter=None):
+                         sent_filter=None):
   """
   A utility function to read a parallel corpus.
 
@@ -453,7 +453,7 @@ def read_parallel_corpus(src_reader: InputReader, trg_reader: InputReader, src_f
     trg_len_ok = max_trg_len is None or trg_sent.sent_len() <= max_trg_len
     keep_sent = src_len_ok and trg_len_ok
 
-    if filter is not None and keep_sent:
+    if sent_filter is not None and keep_sent:
       if hasattr(trg_sent, "words"):
         tmp_trg_sent = "".join([e.replace("__", " ") for e in [trg_reader.vocab[i] for i in trg_sent.words][:-1]])
       else:
@@ -463,7 +463,7 @@ def read_parallel_corpus(src_reader: InputReader, trg_reader: InputReader, src_f
       else:
         tmp_src_sent = src_sent
 
-      keep_sent = filter.keep([tmp_src_sent, tmp_trg_sent])
+      keep_sent = sent_filter.keep([tmp_src_sent, tmp_trg_sent])
 
 
     if keep_sent:

--- a/xnmt/input_readers.py
+++ b/xnmt/input_readers.py
@@ -455,11 +455,11 @@ def read_parallel_corpus(src_reader: InputReader, trg_reader: InputReader, src_f
 
     if filter is not None and keep_sent:
       if hasattr(trg_sent, "words"):
-        tmp_trg_sent = [e.replace("__", " ") for e in [trg_reader.vocab[i] for i in trg_sent.words][:-1]]
+        tmp_trg_sent = "".join([e.replace("__", " ") for e in [trg_reader.vocab[i] for i in trg_sent.words][:-1]])
       else:
         tmp_trg_sent = trg_sent
       if hasattr(src_sent, "words"):
-        tmp_src_sent = [e.replace("__", " ") for e in [src_reader.vocab[i] for i in src_sent.words][:-1]]
+        tmp_src_sent = "".join([e.replace("__", " ") for e in [src_reader.vocab[i] for i in src_sent.words][:-1]])
       else:
         tmp_src_sent = src_sent
 

--- a/xnmt/preproc.py
+++ b/xnmt/preproc.py
@@ -512,8 +512,9 @@ class SentenceFiltererMatchingRegex(SentenceFilterer, Serializable):
     return True
 
 class SentenceFiltererLength(SentenceFilterer):
- """Filters sentences by length"""
+  """Filters sentences by length"""
 
+  @serializable_init
   def __init__(self, spec):
     """Specifies the type of length limitations on the sentences that we'll be getting.
 

--- a/xnmt/preproc.py
+++ b/xnmt/preproc.py
@@ -472,10 +472,13 @@ class SentenceFilterer(object):
           raise RuntimeError("Unknown preprocessing type {}".format(my_spec["type"]))
     return preproc_list
 
-class SentenceFiltererMatchingRegex(SentenceFilterer):
+class SentenceFiltererMatchingRegex(SentenceFilterer, Serializable):
   """Filters sentences via regular expressions.
   A sentence must match the expression to be kept.
   """
+  yaml_tag= '!SentenceFiltererMatchingRegex'
+
+  @serializable_init
   def __init__(self, spec):
     """Specifies the regular expressions to filter the sentences that we'll be getting.
 

--- a/xnmt/preproc.py
+++ b/xnmt/preproc.py
@@ -488,7 +488,7 @@ class SentenceFiltererMatchingRegex(SentenceFilterer, Serializable):
       regex_trg: Equivalent to regex_1
     """
     self.regex = {}
-    idx_map = {"src": 0, "trg": 1}
+    idx_map = {"src": 0, "trg": 1, "hyp": 0, "ref": 1}
     for k, v in spec.items():
       if k == "type":
         pass
@@ -527,7 +527,7 @@ class SentenceFiltererLength(SentenceFilterer):
     self.each_min = {}
     self.overall_max = -1
     self.overall_min = -1
-    idx_map = {"src": 0, "trg": 1}
+    idx_map = {"src": 0, "trg": 1, "hyp": 0, "ref": 1}
     for k, v in spec.items():
       if k == "type":
         pass

--- a/xnmt/preproc.py
+++ b/xnmt/preproc.py
@@ -509,7 +509,7 @@ class SentenceFiltererMatchingRegex(SentenceFilterer):
     return True
 
 class SentenceFiltererLength(SentenceFilterer):
-  """Filters sentences by length"""
+ """Filters sentences by length"""
 
   def __init__(self, spec):
     """Specifies the type of length limitations on the sentences that we'll be getting.

--- a/xnmt/train/regimens.py
+++ b/xnmt/train/regimens.py
@@ -85,7 +85,7 @@ class SimpleTrainingRegimen(train_tasks.SimpleTrainingTask, TrainingRegimen, Ser
     loss_comb_method: method for combining loss across batch elements (``sum`` or ``avg``).
     update_every: simulate large-batch training by accumulating gradients over several steps before updating parameters
     commandline_args:
-    filter:
+    sent_filter:
   """
   yaml_tag = '!SimpleTrainingRegimen'
 
@@ -104,7 +104,7 @@ class SimpleTrainingRegimen(train_tasks.SimpleTrainingTask, TrainingRegimen, Ser
                loss_comb_method: str = Ref("exp_global.loss_comb_method", default="sum"),
                update_every: int = 1,
                commandline_args: dict = Ref("exp_global.commandline_args", default={}),
-               filter = None) -> None:
+               sent_filter = None) -> None:
 
     super().__init__(model=model,
                      src_file=src_file,
@@ -126,7 +126,7 @@ class SimpleTrainingRegimen(train_tasks.SimpleTrainingTask, TrainingRegimen, Ser
                      max_num_train_sents=max_num_train_sents,
                      max_src_len=max_src_len,
                      max_trg_len=max_trg_len,
-                     filter=filter)
+                     sent_filter=sent_filter)
     self.dev_zero = dev_zero
     self.trainer = trainer or optimizers.SimpleSGDTrainer(e0=0.1)
     self.dynet_profiling = commandline_args.get("dynet_profiling", 0) if commandline_args else 0

--- a/xnmt/train/regimens.py
+++ b/xnmt/train/regimens.py
@@ -85,6 +85,7 @@ class SimpleTrainingRegimen(train_tasks.SimpleTrainingTask, TrainingRegimen, Ser
     loss_comb_method: method for combining loss across batch elements (``sum`` or ``avg``).
     update_every: simulate large-batch training by accumulating gradients over several steps before updating parameters
     commandline_args:
+    filter:
   """
   yaml_tag = '!SimpleTrainingRegimen'
 
@@ -102,7 +103,8 @@ class SimpleTrainingRegimen(train_tasks.SimpleTrainingTask, TrainingRegimen, Ser
                max_trg_len: Optional[int] = None,
                loss_comb_method: str = Ref("exp_global.loss_comb_method", default="sum"),
                update_every: int = 1,
-               commandline_args: dict = Ref("exp_global.commandline_args", default={})) -> None:
+               commandline_args: dict = Ref("exp_global.commandline_args", default={}),
+               filter = None) -> None:
 
     super().__init__(model=model,
                      src_file=src_file,
@@ -123,7 +125,8 @@ class SimpleTrainingRegimen(train_tasks.SimpleTrainingTask, TrainingRegimen, Ser
                      sample_train_sents=sample_train_sents,
                      max_num_train_sents=max_num_train_sents,
                      max_src_len=max_src_len,
-                     max_trg_len=max_trg_len)
+                     max_trg_len=max_trg_len,
+                     filter=filter)
     self.dev_zero = dev_zero
     self.trainer = trainer or optimizers.SimpleSGDTrainer(e0=0.1)
     self.dynet_profiling = commandline_args.get("dynet_profiling", 0) if commandline_args else 0

--- a/xnmt/train/tasks.py
+++ b/xnmt/train/tasks.py
@@ -125,7 +125,7 @@ class SimpleTrainingTask(TrainingTask, Serializable):
                name: Optional[str] = None,
                sample_train_sents: Optional[int] = None,
                max_num_train_sents: Optional[int] = None, max_src_len: Optional[int] = None,
-               max_trg_len: Optional[int] = None) -> None:
+               max_trg_len: Optional[int] = None, filter = None) -> None:
     self.src_file = src_file
     self.trg_file = trg_file
     self.dev_tasks = dev_tasks
@@ -153,6 +153,7 @@ class SimpleTrainingTask(TrainingTask, Serializable):
     self.max_num_train_sents = max_num_train_sents
     self.max_src_len = max_src_len
     self.max_trg_len = max_trg_len
+    self.filter = filter
 
     self.batcher = batcher
     self.dev_loss_tracker = loss_trackers.DevLossTracker(self, dev_every, name)
@@ -194,7 +195,8 @@ class SimpleTrainingTask(TrainingTask, Serializable):
                                              sample_sents=self.sample_train_sents,
                                              max_num_sents=self.max_num_train_sents,
                                              max_src_len=self.max_src_len,
-                                             max_trg_len=self.max_trg_len)
+                                             max_trg_len=self.max_trg_len,
+                                             filter=self.filter)
       self.model.src_reader.train = self.model.trg_reader.train = False
       # restart data generation
       self._augmentation_handle = Popen(augment_command + " --epoch %d" % self.training_state.epoch_num, shell=True)
@@ -240,7 +242,8 @@ class SimpleTrainingTask(TrainingTask, Serializable):
                                            src_file=self.src_file, trg_file=self.trg_file,
                                            batcher=self.batcher, sample_sents=self.sample_train_sents,
                                            max_num_sents=self.max_num_train_sents,
-                                           max_src_len=self.max_src_len, max_trg_len=self.max_trg_len)
+                                           max_src_len=self.max_src_len, max_trg_len=self.max_trg_len,
+                                           filter=self.filter)
       self.model.src_reader.train = self.model.trg_reader.train = False
     self.training_state.epoch_seed = random.randint(1,2147483647)
     random.seed(self.training_state.epoch_seed)

--- a/xnmt/train/tasks.py
+++ b/xnmt/train/tasks.py
@@ -125,7 +125,7 @@ class SimpleTrainingTask(TrainingTask, Serializable):
                name: Optional[str] = None,
                sample_train_sents: Optional[int] = None,
                max_num_train_sents: Optional[int] = None, max_src_len: Optional[int] = None,
-               max_trg_len: Optional[int] = None, filter = None) -> None:
+               max_trg_len: Optional[int] = None, sent_filter = None) -> None:
     self.src_file = src_file
     self.trg_file = trg_file
     self.dev_tasks = dev_tasks
@@ -153,7 +153,7 @@ class SimpleTrainingTask(TrainingTask, Serializable):
     self.max_num_train_sents = max_num_train_sents
     self.max_src_len = max_src_len
     self.max_trg_len = max_trg_len
-    self.filter = filter
+    self.sent_filter = sent_filter
 
     self.batcher = batcher
     self.dev_loss_tracker = loss_trackers.DevLossTracker(self, dev_every, name)
@@ -196,7 +196,7 @@ class SimpleTrainingTask(TrainingTask, Serializable):
                                              max_num_sents=self.max_num_train_sents,
                                              max_src_len=self.max_src_len,
                                              max_trg_len=self.max_trg_len,
-                                             filter=self.filter)
+                                             sent_filter=self.sent_filter)
       self.model.src_reader.train = self.model.trg_reader.train = False
       # restart data generation
       self._augmentation_handle = Popen(augment_command + " --epoch %d" % self.training_state.epoch_num, shell=True)
@@ -243,7 +243,7 @@ class SimpleTrainingTask(TrainingTask, Serializable):
                                            batcher=self.batcher, sample_sents=self.sample_train_sents,
                                            max_num_sents=self.max_num_train_sents,
                                            max_src_len=self.max_src_len, max_trg_len=self.max_trg_len,
-                                           filter=self.filter)
+                                           sent_filter=self.sent_filter)
       self.model.src_reader.train = self.model.trg_reader.train = False
     self.training_state.epoch_seed = random.randint(1,2147483647)
     random.seed(self.training_state.epoch_seed)


### PR DESCRIPTION
Added the ability to apply sentence filters after reading the corpus (Not just as a preprocessing step).
example usage:
```
train: !SimpleTrainingRegimen
  sent_filter: !SentenceFiltererMatchingRegex
    spec:
      regex_trg: '^[^\(\)]*$'
```