### PR TITLE
Created stream decoding

### DIFF
--- a/xnmt/inferences.py
+++ b/xnmt/inferences.py
@@ -107,6 +107,7 @@ class Inference(object):
     """
     Generate outputs for a single batch and write them to the output file.
     """
+    batch_size = src_batch.batch_size()
     src_len = src_batch.sent_len()
     if max_src_len is not None and src_len > max_src_len:
       output_txt = "\n".join([NO_DECODING_ATTEMPTED] * batch_size)

--- a/xnmt/inferences.py
+++ b/xnmt/inferences.py
@@ -108,6 +108,7 @@ class Inference(object):
       ref_batch = ref_batches[0]
     else:
       src_batches = batcher.pack(src_batch, None)
+      ref_batch = None
     src_batch = src_batches[0]
     src_len = src_batch.sent_len()
     if max_src_len is not None and src_len > max_src_len:

--- a/xnmt/inferences.py
+++ b/xnmt/inferences.py
@@ -33,15 +33,13 @@ class Inference(object):
             * ``score``: output scores, useful for rescoring
     batcher: inference batcher, needed e.g. in connection with ``pad_src_token_to_multiple``
     reporter: a reporter to create reports for each decoded sentence
-    stream: whether to perform streaming inference (one input at a time) from a file
   """
   @events.register_xnmt_handler
   def __init__(self, src_file: Optional[str] = None, trg_file: Optional[str] = None, ref_file: Optional[str] = None,
                max_src_len: Optional[int] = None, max_num_sents: Optional[int] = None,
                mode: str = "onebest",
                batcher: batchers.InOrderBatcher = bare(batchers.InOrderBatcher, batch_size=1),
-               reporter: Union[None, reports.Reporter, Sequence[reports.Reporter]] = None,
-               stream: bool = True):
+               reporter: Union[None, reports.Reporter, Sequence[reports.Reporter]] = None):
     self.src_file = src_file
     self.trg_file = trg_file
     self.ref_file = ref_file
@@ -50,7 +48,6 @@ class Inference(object):
     self.mode = mode
     self.batcher = batcher
     self.reporter = reporter
-    self.stream = stream
 
   def generate_one(self, generator: 'models.GeneratorModel', src: batchers.Batch, forced_ref_ids) \
           -> List[sent.ReadableSentence]:
@@ -135,7 +132,7 @@ class Inference(object):
                        forced_ref_file: Optional[str] = None,
                        assert_scores: Optional[Sequence[numbers.Real]] = None) -> None:
     """
-    Generate outputs in a streaming format (one input at a time) and write them to file.
+    Generate outputs and write them to file.
 
     Args:
       generator: generator model to use

--- a/xnmt/models/classifiers.py
+++ b/xnmt/models/classifiers.py
@@ -75,8 +75,13 @@ class SequenceClassifier(models.ConditionedModel, models.GeneratorModel, Seriali
       output_action = np.argmax(np_scores, axis=0)
     outputs = []
     for batch_i in range(src.batch_size()):
-      score = np_scores[:, batch_i][output_action[batch_i]]
-      outputs.append(sent.ScalarSentence(value=output_action[batch_i],
+      if src.batch_size() > 1:
+        my_action = output_action[batch_i]
+        score = np_scores[:, batch_i][my_action]
+      else:
+        my_action = output_action
+        score = np_scores[my_action]
+      outputs.append(sent.ScalarSentence(value=my_action,
                                          score=score))
     return outputs
 


### PR DESCRIPTION
Fixes https://github.com/neulab/xnmt/issues/530

Note that this results in two alternative code paths for decoding: one for "batch" where the entire file is read in, batched, and processed, and one for "stream" where a single example is decoded at a time. Currently I set "stream" to default, as batch decoding isn't implemented in a way that makes it any more efficient (see https://github.com/neulab/xnmt/issues/526).