### PR TITLE
fix to beam search stopping criteria

### DIFF
--- a/xnmt/search_strategies.py
+++ b/xnmt/search_strategies.py
@@ -142,10 +142,18 @@ class BeamSearch(Serializable, SearchStrategy):
     completed_hyp = []
     for length in range(self.max_len):
       if len(completed_hyp) >= self.beam_size:
-        break
+        completed_hyp = sorted(completed_hyp, key=lambda hyp: hyp.score, reverse=True)
+        completed_hyp = completed_hyp[:self.beam_size]
+        worst_complete_hyp_score = completed_hyp[-1].score
+        active_hyp = [hyp for hyp in active_hyp if hyp.score >= worst_complete_hyp_score]
+        # Assumption: each additional word will always *decrease* the total score.
+        if len(active_hyp) == 0:
+          break
+
       # Expand hyp
       new_set = []
       for hyp in active_hyp:
+        # Note: prev_word has *not* yet been added to prev_state
         if length > 0:
           prev_word = hyp.word
           prev_state = hyp.output.state


### PR DESCRIPTION
This patch fixes Beam Search's stopping criteria. If searching e.g. with a beam size of five, beam search should return the five best-scoring hypotheses. Previously beam search was returning the five *shortest* hypotheses. Thankfully with modest beam sizes, the end of sentence marker is not usually in the beam until it's at least somewhat appropriate, so the effect is shockingly small.

The new termination strategy is to wait until the score of the best active hypothesis is lower than the Nth best complete hypothesis (where N=beam size). Assuming each subsequent word has a negative score, this criteria guarantees that no active hypothesis could ever be better than the N complete hypotheses already found.

To verify the effectiveness of this patch I've done some experiments with a Chinese--English system trained on TED data, and decoded the dev set with a beam size of 5 and found the following:
Before: 17.45 BLEU   50.5|23.3|12.6|7.2 (brev=0.967)
After: 17.50 BLEU   50.2|23.1|12.5|7.1 (brev=0.976)
206 of 4558 sentences (4.5%) have different translations. The length ratio went from 96.79% to 97.66%.

One might also think that beam size interacts with this. Perhaps if the beam size were larger then </s> would show up earlier in the search and hamper the results. To verify, I re-ran with a beam size of 50:
Before: 17.69   50.9|23.7|12.9|7.4 (brev=0.958)
After: 17.70   50.2|23.1|12.5|7.1 (brev=0.976)
This time 299 of 4558 sentences (6.6%) have different translations. The length ratio went from 95.87% to 97.69%.

Surprisingly the bigger beam size does not show larger gains. Nonetheless, this fix seems to yield small improvements and make the length ratio more stable over different beam sizes.

